### PR TITLE
Add dedicated FAQ knowledge base support

### DIFF
--- a/internal/ai/rag/answer.go
+++ b/internal/ai/rag/answer.go
@@ -40,6 +40,8 @@ func (s *answer) DebugSearch(ctx context.Context, req request.KnowledgeSearchReq
 			ChunkID:         item.ChunkID,
 			DocumentID:      item.DocumentID,
 			DocumentTitle:   item.DocumentTitle,
+			FaqID:           item.FaqID,
+			FaqQuestion:     item.FaqQuestion,
 			ChunkNo:         item.ChunkNo,
 			Title:           item.Title,
 			SectionPath:     item.SectionPath,
@@ -89,6 +91,8 @@ func (s *answer) DebugAnswer(ctx context.Context, req request.KnowledgeAnswerReq
 			ChunkID:         item.ChunkID,
 			DocumentID:      item.DocumentID,
 			DocumentTitle:   item.DocumentTitle,
+			FaqID:           item.FaqID,
+			FaqQuestion:     item.FaqQuestion,
 			ChunkNo:         item.ChunkNo,
 			Title:           item.Title,
 			SectionPath:     item.SectionPath,
@@ -221,6 +225,8 @@ func buildContextHits(results []RetrieveResult) []response.KnowledgeSearchResult
 			ChunkID:         item.ChunkID,
 			DocumentID:      item.DocumentID,
 			DocumentTitle:   item.DocumentTitle,
+			FaqID:           item.FaqID,
+			FaqQuestion:     item.FaqQuestion,
 			ChunkNo:         item.ChunkNo,
 			Title:           item.Title,
 			SectionPath:     item.SectionPath,
@@ -238,7 +244,7 @@ func buildKnowledgeCitations(hits []response.KnowledgeSearchResult, limit int) [
 	citations := make([]response.KnowledgeCitation, 0, limit)
 	seen := make(map[string]struct{})
 	for _, item := range hits {
-		key := fmt.Sprintf("%d|%s|%d", item.DocumentID, item.SectionPath, item.ChunkNo)
+		key := fmt.Sprintf("%d|%d|%s|%d", item.DocumentID, item.FaqID, item.SectionPath, item.ChunkNo)
 		if _, ok := seen[key]; ok {
 			continue
 		}
@@ -246,6 +252,8 @@ func buildKnowledgeCitations(hits []response.KnowledgeSearchResult, limit int) [
 		citations = append(citations, response.KnowledgeCitation{
 			DocumentID:    item.DocumentID,
 			DocumentTitle: item.DocumentTitle,
+			FaqID:         item.FaqID,
+			FaqQuestion:   item.FaqQuestion,
 			ChunkNo:       item.ChunkNo,
 			Title:         item.Title,
 			SectionPath:   item.SectionPath,

--- a/internal/ai/rag/evaluate.go
+++ b/internal/ai/rag/evaluate.go
@@ -180,6 +180,8 @@ func (s *evaluate) compareProvider(ctx context.Context, knowledgeBase *models.Kn
 			ChunkID:         0,
 			DocumentID:      item.Payload.DocumentID,
 			DocumentTitle:   item.Payload.DocumentTitle,
+			FaqID:           item.Payload.FaqID,
+			FaqQuestion:     item.Payload.FaqQuestion,
 			ChunkNo:         item.Payload.ChunkNo,
 			Title:           item.Payload.Title,
 			SectionPath:     item.Payload.SectionPath,

--- a/internal/ai/rag/index.go
+++ b/internal/ai/rag/index.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"time"
@@ -144,6 +145,9 @@ func (s *index) IndexDocument(ctx context.Context, document *models.KnowledgeDoc
 			ContentHash:     buildChunkContentHash(chunk.Content),
 			CharCount:       chunk.CharCount,
 			TokenCount:      chunk.TokenCount,
+			ChunkType:       string(chunk.ChunkType),
+			SectionPath:     chunk.SectionPath,
+			Provider:        providerName,
 			VectorID:        chunkID,
 			Status:          enums.StatusOk,
 			CreatedAt:       time.Now(),
@@ -221,6 +225,103 @@ func (s *index) IndexDocument(ctx context.Context, document *models.KnowledgeDoc
 	return nil
 }
 
+func (s *index) IndexFAQByID(ctx context.Context, faqID int64) error {
+	faq := repositories.KnowledgeFAQRepository.Get(sqls.DB(), faqID)
+	if faq == nil {
+		return fmt.Errorf("faq not found: %d", faqID)
+	}
+	knowledgeBase := repositories.KnowledgeBaseRepository.Get(sqls.DB(), faq.KnowledgeBaseID)
+	if knowledgeBase == nil {
+		return fmt.Errorf("knowledge base not found: %d", faq.KnowledgeBaseID)
+	}
+	if knowledgeBase.KnowledgeType != string(enums.KnowledgeBaseTypeFAQ) {
+		return fmt.Errorf("knowledge base %d is not faq type", knowledgeBase.ID)
+	}
+	existingChunks := repositories.KnowledgeChunkRepository.FindByFaqID(sqls.DB(), faq.ID)
+	content := buildFAQChunkContent(faq)
+	if content == "" {
+		return fmt.Errorf("faq content is empty")
+	}
+
+	provider := vectordb.GetProvider()
+	if provider == nil {
+		return fmt.Errorf("vectordb provider not initialized")
+	}
+	if _, err := ai.Embedding.GetModel(ctx); err != nil {
+		return fmt.Errorf("failed to get embedding model: %w", err)
+	}
+	embeddingResult, err := ai.Embedding.GenerateEmbedding(ctx, content)
+	if err != nil {
+		return fmt.Errorf("failed to generate embedding for faq %d: %w", faq.ID, err)
+	}
+
+	chunkID := buildKnowledgeFAQChunkVectorID(knowledgeBase.ID, faq.ID, 0)
+	chunkModel := models.KnowledgeChunk{
+		KnowledgeBaseID: knowledgeBase.ID,
+		FaqID:           faq.ID,
+		ChunkNo:         0,
+		Title:           faq.Question,
+		Content:         content,
+		ContentHash:     buildChunkContentHash(content),
+		CharCount:       len([]rune(content)),
+		TokenCount:      len([]rune(content)) / 2,
+		ChunkType:       string(enums.KnowledgeChunkTypeFAQ),
+		Provider:        string(enums.KnowledgeChunkProviderFAQ),
+		VectorID:        chunkID,
+		Status:          enums.StatusOk,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+
+	collectionName := s.getCollectionName()
+	collectionInfo, err := provider.GetCollection(ctx, collectionName)
+	if err != nil || collectionInfo == nil {
+		if err := provider.CreateCollection(ctx, collectionName, embeddingResult.Dimension); err != nil {
+			return fmt.Errorf("failed to create collection: %w", err)
+		}
+	}
+
+	existingVectorIDs := make([]string, 0, len(existingChunks))
+	for _, chunk := range existingChunks {
+		if strs.IsNotBlank(chunk.VectorID) {
+			existingVectorIDs = append(existingVectorIDs, chunk.VectorID)
+		}
+	}
+	if len(existingVectorIDs) > 0 {
+		if err := provider.DeleteVectors(ctx, collectionName, existingVectorIDs); err != nil {
+			return fmt.Errorf("failed to delete old vectors: %w", err)
+		}
+	}
+
+	if err := provider.UpsertVectors(ctx, collectionName, []vectordb.Vector{{
+		ID:     chunkID,
+		Vector: embeddingResult.Vector,
+		Payload: vectordb.ChunkPayload{
+			KnowledgeBaseID: knowledgeBase.ID,
+			FaqID:           faq.ID,
+			FaqQuestion:     faq.Question,
+			ChunkNo:         0,
+			ChunkType:       string(enums.KnowledgeChunkTypeFAQ),
+			Content:         content,
+			Title:           faq.Question,
+			Provider:        string(enums.KnowledgeChunkProviderFAQ),
+		},
+	}}); err != nil {
+		return fmt.Errorf("failed to upsert vectors: %w", err)
+	}
+
+	if err := sqls.WithTransaction(func(ctx *sqls.TxContext) error {
+		if err := ctx.Tx.Where("faq_id = ?", faq.ID).Delete(&models.KnowledgeChunk{}).Error; err != nil {
+			return err
+		}
+		return ctx.Tx.Create(&chunkModel).Error
+	}); err != nil {
+		return fmt.Errorf("failed to save faq chunk: %w", err)
+	}
+
+	return nil
+}
+
 func (s *index) RemoveDocumentIndex(ctx context.Context, documentID int64) error {
 	document := repositories.KnowledgeDocumentRepository.Get(sqls.DB(), documentID)
 	if document == nil {
@@ -273,12 +374,59 @@ func (s *index) removeDocumentIndexByChunks(ctx context.Context, knowledgeBaseID
 	return nil
 }
 
+func (s *index) RemoveFAQIndex(ctx context.Context, faqID int64) error {
+	faq := repositories.KnowledgeFAQRepository.Get(sqls.DB(), faqID)
+	if faq == nil {
+		return nil
+	}
+	chunks := repositories.KnowledgeChunkRepository.FindByFaqID(sqls.DB(), faqID)
+	return s.removeFAQIndexByChunks(ctx, faq.KnowledgeBaseID, faqID, chunks)
+}
+
+func (s *index) RemoveFAQIndexByChunkModels(ctx context.Context, knowledgeBaseID int64, faqID int64, chunks []models.KnowledgeChunk) error {
+	return s.removeFAQIndexByChunks(ctx, knowledgeBaseID, faqID, chunks)
+}
+
+func (s *index) removeFAQIndexByChunks(ctx context.Context, knowledgeBaseID int64, faqID int64, chunks []models.KnowledgeChunk) error {
+	if len(chunks) == 0 {
+		return nil
+	}
+	collectionName := s.getCollectionName()
+	provider := vectordb.GetProvider()
+	if provider == nil {
+		return fmt.Errorf("vectordb provider not initialized")
+	}
+	vectorIDs := make([]string, 0, len(chunks))
+	for _, chunk := range chunks {
+		if chunk.VectorID != "" {
+			vectorIDs = append(vectorIDs, chunk.VectorID)
+		}
+	}
+	if len(vectorIDs) > 0 {
+		if err := provider.DeleteVectors(ctx, collectionName, vectorIDs); err != nil {
+			slog.Error("Failed to delete faq vectors", "error", err)
+		}
+	}
+	if err := sqls.WithTransaction(func(ctx *sqls.TxContext) error {
+		return ctx.Tx.Where("faq_id = ?", faqID).Delete(&models.KnowledgeChunk{}).Error
+	}); err != nil {
+		return fmt.Errorf("failed to delete faq chunks: %w", err)
+	}
+	slog.Info("FAQ index removed", "faq_id", faqID, "chunks_removed", len(chunks))
+	return nil
+}
+
 func (s *index) getCollectionName() string {
 	return knowledgeCollectionName
 }
 
 func buildKnowledgeChunkVectorID(knowledgeBaseID int64, documentID int64, chunkNo int) string {
 	raw := fmt.Sprintf("kb:%d:doc:%d:chunk:%d", knowledgeBaseID, documentID, chunkNo)
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(raw)).String()
+}
+
+func buildKnowledgeFAQChunkVectorID(knowledgeBaseID int64, faqID int64, chunkNo int) string {
+	raw := fmt.Sprintf("kb:%d:faq:%d:chunk:%d", knowledgeBaseID, faqID, chunkNo)
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(raw)).String()
 }
 
@@ -335,32 +483,50 @@ func (s *index) RebuildKnowledgeBaseIndex(ctx context.Context, knowledgeBaseID i
 		return err
 	}
 
-	documents := repositories.KnowledgeDocumentRepository.Find(sqls.DB(), sqls.NewCnd().
-		Eq("knowledge_base_id", knowledgeBaseID).
-		Where("status != ?", enums.StatusDeleted))
-	if len(documents) == 0 {
-		slog.Info("No documents found in knowledge base, nothing to rebuild", "knowledge_base_id", knowledgeBaseID)
-		return nil
-	}
-
-	documentIDs := make([]int64, 0, len(documents))
-	for _, doc := range documents {
-		documentIDs = append(documentIDs, doc.ID)
-	}
-	if err := s.markKnowledgeBaseDocumentsIndexPending(knowledgeBaseID, documentIDs); err != nil {
-		slog.Error("Failed to mark knowledge base documents index as pending", "knowledge_base_id", knowledgeBaseID, "error", err)
-	}
-
-	slog.Info("Rebuilding knowledge base index", "knowledge_base_id", knowledgeBaseID, "document_count", len(documents))
-
 	successCount := 0
 	failedCount := 0
-	for _, doc := range documents {
-		if err := s.IndexDocumentByID(ctx, doc.ID); err != nil {
-			slog.Error("Failed to index document", "document_id", doc.ID, "error", err)
-			failedCount++
-		} else {
-			successCount++
+	if knowledgeBase.KnowledgeType == string(enums.KnowledgeBaseTypeFAQ) {
+		faqs := repositories.KnowledgeFAQRepository.Find(sqls.DB(), sqls.NewCnd().
+			Eq("knowledge_base_id", knowledgeBaseID).
+			Where("status != ?", enums.StatusDeleted))
+		if len(faqs) == 0 {
+			slog.Info("No faqs found in knowledge base, nothing to rebuild", "knowledge_base_id", knowledgeBaseID)
+			return nil
+		}
+		slog.Info("Rebuilding faq knowledge base index", "knowledge_base_id", knowledgeBaseID, "faq_count", len(faqs))
+		for _, faq := range faqs {
+			if err := s.IndexFAQByID(ctx, faq.ID); err != nil {
+				slog.Error("Failed to index faq", "faq_id", faq.ID, "error", err)
+				failedCount++
+			} else {
+				successCount++
+			}
+		}
+	} else {
+		documents := repositories.KnowledgeDocumentRepository.Find(sqls.DB(), sqls.NewCnd().
+			Eq("knowledge_base_id", knowledgeBaseID).
+			Where("status != ?", enums.StatusDeleted))
+		if len(documents) == 0 {
+			slog.Info("No documents found in knowledge base, nothing to rebuild", "knowledge_base_id", knowledgeBaseID)
+			return nil
+		}
+
+		documentIDs := make([]int64, 0, len(documents))
+		for _, doc := range documents {
+			documentIDs = append(documentIDs, doc.ID)
+		}
+		if err := s.markKnowledgeBaseDocumentsIndexPending(knowledgeBaseID, documentIDs); err != nil {
+			slog.Error("Failed to mark knowledge base documents index as pending", "knowledge_base_id", knowledgeBaseID, "error", err)
+		}
+
+		slog.Info("Rebuilding knowledge base index", "knowledge_base_id", knowledgeBaseID, "document_count", len(documents))
+		for _, doc := range documents {
+			if err := s.IndexDocumentByID(ctx, doc.ID); err != nil {
+				slog.Error("Failed to index document", "document_id", doc.ID, "error", err)
+				failedCount++
+			} else {
+				successCount++
+			}
 		}
 	}
 
@@ -370,6 +536,46 @@ func (s *index) RebuildKnowledgeBaseIndex(ctx context.Context, knowledgeBaseID i
 		"failed_count", failedCount)
 
 	return nil
+}
+
+func buildFAQChunkContent(faq *models.KnowledgeFAQ) string {
+	if faq == nil {
+		return ""
+	}
+	parts := []string{fmt.Sprintf("问题：%s", faq.Question)}
+	var similarQuestions []string
+	if faq.SimilarQuestions != "" {
+		_ = json.Unmarshal([]byte(faq.SimilarQuestions), &similarQuestions)
+	}
+	if len(similarQuestions) > 0 {
+		parts = append(parts, fmt.Sprintf("相似问：%s", joinSimilarQuestions(similarQuestions)))
+	}
+	parts = append(parts, fmt.Sprintf("回答：%s", faq.Answer))
+	content := ""
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if content != "" {
+			content += "\n"
+		}
+		content += part
+	}
+	return content
+}
+
+func joinSimilarQuestions(items []string) string {
+	result := ""
+	for _, item := range items {
+		if item == "" {
+			continue
+		}
+		if result != "" {
+			result += "；"
+		}
+		result += item
+	}
+	return result
 }
 
 func (s *index) markDocumentIndexPending(documentID int64) error {

--- a/internal/ai/rag/retrieve.go
+++ b/internal/ai/rag/retrieve.go
@@ -89,20 +89,33 @@ func (s *retrieve) Retrieve(ctx context.Context, req RetrieveRequest) ([]Retriev
 			continue
 		}
 
-		document := repositories.KnowledgeDocumentRepository.Get(sqls.DB(), chunk.DocumentID)
-		if document == nil || document.Status != enums.StatusOk {
-			continue
+		documentTitle := ""
+		faqQuestion := ""
+		if chunk.DocumentID > 0 {
+			document := repositories.KnowledgeDocumentRepository.Get(sqls.DB(), chunk.DocumentID)
+			if document == nil || document.Status != enums.StatusOk {
+				continue
+			}
+			documentTitle = document.Title
 		}
-		documentTitle := document.Title
+		if chunk.FaqID > 0 {
+			faq := repositories.KnowledgeFAQRepository.Get(sqls.DB(), chunk.FaqID)
+			if faq == nil || faq.Status != enums.StatusOk {
+				continue
+			}
+			faqQuestion = faq.Question
+		}
 
 		results = append(results, RetrieveResult{
 			KnowledgeBaseID: chunk.KnowledgeBaseID,
 			ChunkID:         chunk.ID,
 			DocumentID:      chunk.DocumentID,
 			DocumentTitle:   documentTitle,
+			FaqID:           chunk.FaqID,
+			FaqQuestion:     faqQuestion,
 			ChunkNo:         chunk.ChunkNo,
 			Title:           chunk.Title,
-			SectionPath:     sr.Payload.SectionPath,
+			SectionPath:     chunk.SectionPath,
 			Content:         chunk.Content,
 			Score:           sr.Score,
 			ChunkType:       extractChunkType(sr.Payload),
@@ -287,6 +300,9 @@ func mergeAdjacentResults(results []RetrieveResult) []RetrieveResult {
 }
 
 func canMergeContextResult(left, right RetrieveResult) bool {
+	if left.FaqID > 0 || right.FaqID > 0 {
+		return false
+	}
 	if left.DocumentID != right.DocumentID {
 		return false
 	}
@@ -300,6 +316,9 @@ func canMergeContextResult(left, right RetrieveResult) bool {
 }
 
 func buildSectionKey(item RetrieveResult) string {
+	if item.FaqID > 0 {
+		return fmt.Sprintf("faq:%d", item.FaqID)
+	}
 	sectionPath := strings.TrimSpace(item.SectionPath)
 	if sectionPath != "" {
 		return fmt.Sprintf("%d|%s", item.DocumentID, sectionPath)
@@ -312,6 +331,16 @@ func buildSectionKey(item RetrieveResult) string {
 }
 
 func buildContextChunkText(item RetrieveResult) string {
+	if item.FaqID > 0 {
+		title := strings.TrimSpace(item.FaqQuestion)
+		if title == "" {
+			title = strings.TrimSpace(item.Title)
+		}
+		if title == "" {
+			title = fmt.Sprintf("FAQ#%d", item.FaqID)
+		}
+		return fmt.Sprintf("【FAQ：%s】\n%s\n\n", title, item.Content)
+	}
 	title := strings.TrimSpace(item.DocumentTitle)
 	if title == "" {
 		title = fmt.Sprintf("文档#%d", item.DocumentID)

--- a/internal/ai/rag/retrieve_log.go
+++ b/internal/ai/rag/retrieve_log.go
@@ -153,6 +153,8 @@ func (s *retrieveLog) CreateRetrieveLog(req *CreateRetrieveLogRequest, _ *dto.Au
 				ChunkID:         hit.ChunkID,
 				DocumentID:      hit.DocumentID,
 				DocumentTitle:   hit.DocumentTitle,
+				FaqID:           hit.FaqID,
+				FaqQuestion:     hit.FaqQuestion,
 				ChunkNo:         hit.ChunkNo,
 				Title:           hit.Title,
 				SectionPath:     hit.SectionPath,
@@ -279,10 +281,16 @@ func distinctSectionPaths(hits []response.KnowledgeSearchResult) []string {
 }
 
 func buildKnowledgeSearchResultKey(item response.KnowledgeSearchResult) string {
+	if item.FaqID > 0 {
+		return fmt.Sprintf("faq:%d|%d", item.FaqID, item.ChunkNo)
+	}
 	return fmt.Sprintf("%d|%s|%d", item.DocumentID, item.SectionPath, item.ChunkNo)
 }
 
 func buildKnowledgeCitationKey(item response.KnowledgeCitation) string {
+	if item.FaqID > 0 {
+		return fmt.Sprintf("faq:%d|%d", item.FaqID, item.ChunkNo)
+	}
 	return fmt.Sprintf("%d|%s|%d", item.DocumentID, item.SectionPath, item.ChunkNo)
 }
 

--- a/internal/ai/rag/types.go
+++ b/internal/ai/rag/types.go
@@ -12,6 +12,8 @@ type RetrieveResult struct {
 	ChunkID         int64   `json:"chunkId"`
 	DocumentID      int64   `json:"documentId"`
 	DocumentTitle   string  `json:"documentTitle"`
+	FaqID           int64   `json:"faqId"`
+	FaqQuestion     string  `json:"faqQuestion"`
 	ChunkNo         int     `json:"chunkNo"`
 	Title           string  `json:"title"`
 	SectionPath     string  `json:"sectionPath"`

--- a/internal/ai/rag/vectordb/payload.go
+++ b/internal/ai/rag/vectordb/payload.go
@@ -9,6 +9,8 @@ type ChunkPayload struct {
 	KnowledgeBaseID int64  `json:"knowledge_base_id"`
 	DocumentID      int64  `json:"document_id"`
 	DocumentTitle   string `json:"document_title"`
+	FaqID           int64  `json:"faq_id"`
+	FaqQuestion     string `json:"faq_question"`
 	ChunkNo         int    `json:"chunk_no"`
 	ChunkType       string `json:"chunk_type"`
 	SectionPath     string `json:"section_path"`
@@ -29,6 +31,8 @@ func ChunkPayloadFromMap(data map[string]any) ChunkPayload {
 		KnowledgeBaseID: cast.ToInt64(data["knowledge_base_id"]),
 		DocumentID:      cast.ToInt64(data["document_id"]),
 		DocumentTitle:   cast.ToString(data["document_title"]),
+		FaqID:           cast.ToInt64(data["faq_id"]),
+		FaqQuestion:     cast.ToString(data["faq_question"]),
 		ChunkNo:         cast.ToInt(data["chunk_no"]),
 		ChunkType:       cast.ToString(data["chunk_type"]),
 		SectionPath:     cast.ToString(data["section_path"]),

--- a/internal/bootstrap/server.go
+++ b/internal/bootstrap/server.go
@@ -154,6 +154,7 @@ func addRouter(app *iris.Application, cfg *config.Config) {
 		m.Party("/asset").Handle(new(console.AssetController))
 		m.Party("/knowledge-base").Handle(new(console.KnowledgeBaseController))
 		m.Party("/knowledge-document").Handle(new(console.KnowledgeDocumentController))
+		m.Party("/knowledge-faq").Handle(new(console.KnowledgeFAQController))
 		m.Party("/knowledge-retrieve").Handle(new(console.KnowledgeRetrieveController))
 		m.Party("/knowledge-retrieve-log").Handle(new(console.KnowledgeRetrieveLogController))
 		m.Party("/agent-run-log").Handle(new(console.AgentRunLogController))

--- a/internal/builders/knowledge_builder.go
+++ b/internal/builders/knowledge_builder.go
@@ -4,6 +4,7 @@ import (
 	"cs-agent/internal/models"
 	"cs-agent/internal/pkg/dto/response"
 	"cs-agent/internal/pkg/enums"
+	"encoding/json"
 )
 
 func BuildKnowledgeBase(item *models.KnowledgeBase) response.KnowledgeBaseResponse {
@@ -11,6 +12,8 @@ func BuildKnowledgeBase(item *models.KnowledgeBase) response.KnowledgeBaseRespon
 		ID:                    item.ID,
 		Name:                  item.Name,
 		Description:           item.Description,
+		KnowledgeType:         item.KnowledgeType,
+		KnowledgeTypeName:     enums.GetKnowledgeBaseTypeLabel(enums.KnowledgeBaseType(item.KnowledgeType)),
 		Status:                item.Status,
 		StatusName:            enums.GetStatusLabel(item.Status),
 		DefaultTopK:           item.DefaultTopK,
@@ -50,6 +53,23 @@ func BuildKnowledgeDocument(item *models.KnowledgeDocument) response.KnowledgeDo
 		UpdatedAt:       item.UpdatedAt,
 		CreateUserName:  item.CreateUserName,
 		UpdateUserName:  item.UpdateUserName,
+	}
+}
+
+func BuildKnowledgeFAQ(item *models.KnowledgeFAQ) response.KnowledgeFAQResponse {
+	return response.KnowledgeFAQResponse{
+		ID:               item.ID,
+		KnowledgeBaseID:  item.KnowledgeBaseID,
+		Question:         item.Question,
+		Answer:           item.Answer,
+		SimilarQuestions: parseSimilarQuestions(item.SimilarQuestions),
+		Status:           item.Status,
+		StatusName:       enums.GetStatusLabel(item.Status),
+		Remark:           item.Remark,
+		CreatedAt:        item.CreatedAt,
+		UpdatedAt:        item.UpdatedAt,
+		CreateUserName:   item.CreateUserName,
+		UpdateUserName:   item.UpdateUserName,
 	}
 }
 
@@ -98,6 +118,8 @@ func BuildKnowledgeRetrieveHitResponse(item *models.KnowledgeRetrieveHit) respon
 		ChunkID:         item.ChunkID,
 		DocumentID:      item.DocumentID,
 		DocumentTitle:   item.DocumentTitle,
+		FaqID:           item.FaqID,
+		FaqQuestion:     item.FaqQuestion,
 		ChunkNo:         item.ChunkNo,
 		Title:           item.Title,
 		SectionPath:     item.SectionPath,
@@ -112,4 +134,15 @@ func BuildKnowledgeRetrieveHitResponse(item *models.KnowledgeRetrieveHit) respon
 		Snippet:         item.Snippet,
 		CreatedAt:       item.CreatedAt,
 	}
+}
+
+func parseSimilarQuestions(raw string) []string {
+	if raw == "" {
+		return []string{}
+	}
+	var items []string
+	if err := json.Unmarshal([]byte(raw), &items); err != nil {
+		return []string{}
+	}
+	return items
 }

--- a/internal/controllers/console/knowledge_base_controller.go
+++ b/internal/controllers/console/knowledge_base_controller.go
@@ -35,8 +35,10 @@ func (c *KnowledgeBaseController) AnyList() *web.JsonResult {
 	results := make([]response.KnowledgeBaseResponse, 0, len(list))
 	for _, item := range list {
 		docCount := repositories.KnowledgeDocumentRepository.CountByKnowledgeBaseID(sqls.DB(), item.ID)
+		faqCount := repositories.KnowledgeFAQRepository.CountByKnowledgeBaseID(sqls.DB(), item.ID)
 		resp := builders.BuildKnowledgeBase(&item)
 		resp.DocumentCount = docCount
+		resp.FAQCount = faqCount
 		results = append(results, resp)
 	}
 	return web.JsonData(&web.PageResult{Results: results, Page: paging})
@@ -69,6 +71,7 @@ func (c *KnowledgeBaseController) GetBy(id int64) *web.JsonResult {
 	}
 	resp := builders.BuildKnowledgeBase(item)
 	resp.DocumentCount = repositories.KnowledgeDocumentRepository.CountByKnowledgeBaseID(sqls.DB(), item.ID)
+	resp.FAQCount = repositories.KnowledgeFAQRepository.CountByKnowledgeBaseID(sqls.DB(), item.ID)
 	return web.JsonData(resp)
 }
 

--- a/internal/controllers/console/knowledge_faq_controller.go
+++ b/internal/controllers/console/knowledge_faq_controller.go
@@ -1,0 +1,93 @@
+package console
+
+import (
+	"cs-agent/internal/builders"
+	"cs-agent/internal/pkg/constants"
+	"cs-agent/internal/pkg/dto/request"
+	"cs-agent/internal/pkg/dto/response"
+	"cs-agent/internal/services"
+
+	"github.com/kataras/iris/v12"
+	"github.com/mlogclub/simple/web"
+	"github.com/mlogclub/simple/web/params"
+)
+
+type KnowledgeFAQController struct {
+	Ctx iris.Context
+}
+
+func (c *KnowledgeFAQController) AnyList() *web.JsonResult {
+	if _, err := services.AuthService.RequirePermission(c.Ctx, constants.PermissionKnowledgeFAQView); err != nil {
+		return web.JsonError(err)
+	}
+
+	cnd := params.NewPagedSqlCnd(c.Ctx,
+		params.QueryFilter{ParamName: "knowledgeBaseId"},
+		params.QueryFilter{ParamName: "question", Op: params.Like},
+	).Desc("id")
+	list, paging := services.KnowledgeFAQService.FindPageByCnd(cnd)
+	results := make([]response.KnowledgeFAQResponse, 0, len(list))
+	for _, item := range list {
+		results = append(results, builders.BuildKnowledgeFAQ(&item))
+	}
+	return web.JsonData(&web.PageResult{Results: results, Page: paging})
+}
+
+func (c *KnowledgeFAQController) GetBy(id int64) *web.JsonResult {
+	if _, err := services.AuthService.RequirePermission(c.Ctx, constants.PermissionKnowledgeFAQView); err != nil {
+		return web.JsonError(err)
+	}
+
+	item := services.KnowledgeFAQService.Get(id)
+	if item == nil {
+		return web.JsonErrorMsg("FAQ不存在")
+	}
+	return web.JsonData(builders.BuildKnowledgeFAQ(item))
+}
+
+func (c *KnowledgeFAQController) PostCreate() *web.JsonResult {
+	operator, err := services.AuthService.RequirePermission(c.Ctx, constants.PermissionKnowledgeFAQCreate)
+	if err != nil {
+		return web.JsonError(err)
+	}
+	req := request.CreateKnowledgeFAQRequest{}
+	if err := params.ReadJSON(c.Ctx, &req); err != nil {
+		return web.JsonError(err)
+	}
+	item, err := services.KnowledgeFAQService.CreateKnowledgeFAQ(req, operator)
+	if err != nil {
+		return web.JsonError(err)
+	}
+	return web.JsonData(builders.BuildKnowledgeFAQ(item))
+}
+
+func (c *KnowledgeFAQController) PostUpdate() *web.JsonResult {
+	operator, err := services.AuthService.RequirePermission(c.Ctx, constants.PermissionKnowledgeFAQUpdate)
+	if err != nil {
+		return web.JsonError(err)
+	}
+	req := request.UpdateKnowledgeFAQRequest{}
+	if err := params.ReadJSON(c.Ctx, &req); err != nil {
+		return web.JsonError(err)
+	}
+	if err := services.KnowledgeFAQService.UpdateKnowledgeFAQ(req, operator); err != nil {
+		return web.JsonError(err)
+	}
+	return web.JsonSuccess()
+}
+
+func (c *KnowledgeFAQController) PostDelete() *web.JsonResult {
+	if _, err := services.AuthService.RequirePermission(c.Ctx, constants.PermissionKnowledgeFAQDelete); err != nil {
+		return web.JsonError(err)
+	}
+	var req struct {
+		ID int64 `json:"id"`
+	}
+	if err := params.ReadJSON(c.Ctx, &req); err != nil {
+		return web.JsonError(err)
+	}
+	if err := services.KnowledgeFAQService.DeleteKnowledgeFAQ(req.ID); err != nil {
+		return web.JsonError(err)
+	}
+	return web.JsonSuccess()
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -45,6 +45,7 @@ var Models = []any{
 	&AIConfig{},
 	&KnowledgeBase{},
 	&KnowledgeDocument{},
+	&KnowledgeFAQ{},
 	&KnowledgeChunk{},
 	&KnowledgeRetrieveLog{},
 	&KnowledgeRetrieveHit{},
@@ -604,29 +605,28 @@ type AIConfig struct {
 
 // KnowledgeBase 知识库主表。
 type KnowledgeBase struct {
-	ID                    int64        `gorm:"primaryKey;autoIncrement"`                       // ID 为知识库主键。
-	TenantID              int64        `gorm:"type:bigint;not null;default:0;index"`           // TenantID 为租户ID。
-	Name                  string       `gorm:"type:varchar(100);not null;default:'';index"`    // Name 为知识库名称。
-	Description           string       `gorm:"type:text"`                                      // Description 为知识库描述。
-	Status                enums.Status `gorm:"type:int;not null;index"`                        // Status 为状态
-	DefaultTopK           int          `gorm:"type:int;not null;default:10"`                   // DefaultTopK 为默认召回数量。
-	DefaultScoreThreshold float64      `gorm:"type:decimal(5,4);not null;default:0.5"`         // DefaultScoreThreshold 为默认相似度阈值。
-	DefaultRerankLimit    int          `gorm:"type:int;not null;default:5"`                    // DefaultRerankLimit 为默认重排后保留数量。
-	ChunkProvider         string       `gorm:"type:varchar(30);not null;default:'structured'"` // ChunkProvider 为知识库分块策略 provider。
-	ChunkTargetTokens     int          `gorm:"type:int;not null;default:300"`                  // ChunkTargetTokens 为目标 chunk token 数。
-	ChunkMaxTokens        int          `gorm:"type:int;not null;default:400"`                  // ChunkMaxTokens 为单 chunk 最大 token 数。
-	ChunkOverlapTokens    int          `gorm:"type:int;not null;default:40"`                   // ChunkOverlapTokens 为相邻 chunk 重叠 token 数。
-	AnswerMode            int          `gorm:"type:int;not null;default:1"`                    // AnswerMode 为回答模式：1严格知识库模式 2辅助解释模式。
-	FallbackMode          int          `gorm:"type:int;not null;default:1"`                    // FallbackMode 为兜底模式：1声明无答案 2引导换问法 3转人工。
-	SortNo                int          `gorm:"type:int;not null;default:0;index"`              // SortNo 为排序号，用于后台展示和知识库的人工排序管理。
-	Remark                string       `gorm:"type:text"`                                      // Remark 为备注。
+	ID                    int64        `gorm:"primaryKey;autoIncrement"`                           // ID 为知识库主键。
+	Name                  string       `gorm:"type:varchar(100);not null;default:'';index"`        // Name 为知识库名称。
+	Description           string       `gorm:"type:text"`                                          // Description 为知识库描述。
+	KnowledgeType         string       `gorm:"type:varchar(20);not null;default:'document';index"` // KnowledgeType 为知识库类型：document/faq。
+	Status                enums.Status `gorm:"type:int;not null;index"`                            // Status 为状态
+	DefaultTopK           int          `gorm:"type:int;not null;default:10"`                       // DefaultTopK 为默认召回数量。
+	DefaultScoreThreshold float64      `gorm:"type:decimal(5,4);not null;default:0.5"`             // DefaultScoreThreshold 为默认相似度阈值。
+	DefaultRerankLimit    int          `gorm:"type:int;not null;default:5"`                        // DefaultRerankLimit 为默认重排后保留数量。
+	ChunkProvider         string       `gorm:"type:varchar(30);not null;default:'structured'"`     // ChunkProvider 为知识库分块策略 provider。
+	ChunkTargetTokens     int          `gorm:"type:int;not null;default:300"`                      // ChunkTargetTokens 为目标 chunk token 数。
+	ChunkMaxTokens        int          `gorm:"type:int;not null;default:400"`                      // ChunkMaxTokens 为单 chunk 最大 token 数。
+	ChunkOverlapTokens    int          `gorm:"type:int;not null;default:40"`                       // ChunkOverlapTokens 为相邻 chunk 重叠 token 数。
+	AnswerMode            int          `gorm:"type:int;not null;default:1"`                        // AnswerMode 为回答模式：1严格知识库模式 2辅助解释模式。
+	FallbackMode          int          `gorm:"type:int;not null;default:1"`                        // FallbackMode 为兜底模式：1声明无答案 2引导换问法 3转人工。
+	SortNo                int          `gorm:"type:int;not null;default:0;index"`                  // SortNo 为排序号，用于后台展示和知识库的人工排序管理。
+	Remark                string       `gorm:"type:text"`                                          // Remark 为备注。
 	AuditFields
 }
 
 // KnowledgeDocument 知识文档主表。
 type KnowledgeDocument struct {
 	ID              int64                              `gorm:"primaryKey;autoIncrement"`                          // ID 为文档主键。
-	TenantID        int64                              `gorm:"type:bigint;not null;default:0;index"`              // TenantID 为租户ID。
 	KnowledgeBaseID int64                              `gorm:"type:bigint;not null;index"`                        // KnowledgeBaseID 为所属知识库ID。
 	Title           string                             `gorm:"type:varchar(255);not null;default:'';index"`       // Title 为文档标题。
 	ContentType     enums.KnowledgeDocumentContentType `gorm:"type:varchar(20);not null;default:'html'"`          // ContentType 为内容类型：html/markdown。
@@ -639,18 +639,33 @@ type KnowledgeDocument struct {
 	AuditFields
 }
 
+// KnowledgeFAQ FAQ 条目主表。
+type KnowledgeFAQ struct {
+	ID               int64        `gorm:"primaryKey;autoIncrement"`                    // ID 为 FAQ 主键。
+	KnowledgeBaseID  int64        `gorm:"type:bigint;not null;index"`                  // KnowledgeBaseID 为所属 FAQ 知识库 ID。
+	Question         string       `gorm:"type:varchar(500);not null;default:'';index"` // Question 为标准问题。
+	Answer           string       `gorm:"type:text"`                                   // Answer 为标准答案。
+	SimilarQuestions string       `gorm:"type:text"`                                   // SimilarQuestions 为相似问 JSON 数组。
+	Status           enums.Status `gorm:"type:int;not null;default:0;index"`           // Status 为状态。
+	Remark           string       `gorm:"type:text"`                                   // Remark 为备注。
+	AuditFields
+}
+
 // KnowledgeChunk 切片元数据表。
 type KnowledgeChunk struct {
 	ID              int64        `gorm:"primaryKey;autoIncrement"`                    // ID 为切片主键。
-	TenantID        int64        `gorm:"type:bigint;not null;default:0;index"`        // TenantID 为租户ID。
 	KnowledgeBaseID int64        `gorm:"type:bigint;not null;index"`                  // KnowledgeBaseID 为知识库ID。
-	DocumentID      int64        `gorm:"type:bigint;not null;index"`                  // DocumentID 为文档ID。
+	DocumentID      int64        `gorm:"type:bigint;not null;default:0;index"`        // DocumentID 为文档ID。
+	FaqID           int64        `gorm:"type:bigint;not null;default:0;index"`        // FaqID 为 FAQ ID。
 	ChunkNo         int          `gorm:"type:int;not null;default:0;index"`           // ChunkNo 为切片序号。
 	Title           string       `gorm:"type:varchar(255);not null;default:''"`       // Title 为切片标题。
 	Content         string       `gorm:"type:text"`                                   // Content 为切片内容。
 	ContentHash     string       `gorm:"type:varchar(64);not null;default:'';index"`  // ContentHash 为内容哈希。
 	CharCount       int          `gorm:"type:int;not null;default:0"`                 // CharCount 为字符数。
 	TokenCount      int          `gorm:"type:int;not null;default:0"`                 // TokenCount 为token数。
+	ChunkType       string       `gorm:"type:varchar(30);not null;default:''"`        // ChunkType 为切片类型。
+	SectionPath     string       `gorm:"type:text"`                                   // SectionPath 为章节路径。
+	Provider        string       `gorm:"type:varchar(30);not null;default:''"`        // Provider 为分块 provider。
 	Status          enums.Status `gorm:"type:int;not null;default:0;index"`           // Status 为状态：1有效 2已删除。
 	VectorID        string       `gorm:"type:varchar(100);not null;default:'';index"` // VectorID 为向量库中的point ID。
 	CreatedAt       time.Time    `gorm:"type:datetime;not null;index"`
@@ -699,6 +714,8 @@ type KnowledgeRetrieveHit struct {
 	ChunkID         int64     `gorm:"type:bigint;not null;index"`            // ChunkID 为切片ID。
 	DocumentID      int64     `gorm:"type:bigint;not null;index"`            // DocumentID 为文档ID。
 	DocumentTitle   string    `gorm:"type:varchar(255);not null;default:''"` // DocumentTitle 为文档标题。
+	FaqID           int64     `gorm:"type:bigint;not null;default:0;index"`  // FaqID 为 FAQ ID。
+	FaqQuestion     string    `gorm:"type:varchar(500);not null;default:''"` // FaqQuestion 为 FAQ 问题。
 	ChunkNo         int       `gorm:"type:int;not null;default:0"`           // ChunkNo 为切片序号。
 	Title           string    `gorm:"type:varchar(255);not null;default:''"` // Title 为切片标题。
 	SectionPath     string    `gorm:"type:text"`                             // SectionPath 为章节路径。

--- a/internal/pkg/constants/auth.go
+++ b/internal/pkg/constants/auth.go
@@ -150,6 +150,10 @@ var (
 	PermissionKnowledgeDocumentCreate = Permission{Name: "创建知识文档", Code: "knowledgeDocument.create", Type: "api", GroupName: "knowledgeDocument", Method: "POST", APIPath: "/api/console/knowledge-document/create", SortNo: 1520}
 	PermissionKnowledgeDocumentUpdate = Permission{Name: "更新知识文档", Code: "knowledgeDocument.update", Type: "api", GroupName: "knowledgeDocument", Method: "POST", APIPath: "/api/console/knowledge-document/update", SortNo: 1530}
 	PermissionKnowledgeDocumentDelete = Permission{Name: "删除知识文档", Code: "knowledgeDocument.delete", Type: "api", GroupName: "knowledgeDocument", Method: "POST", APIPath: "/api/console/knowledge-document/delete", SortNo: 1540}
+	PermissionKnowledgeFAQView        = Permission{Name: "查看知识FAQ", Code: "knowledgeFAQ.view", Type: "api", GroupName: "knowledgeFAQ", Method: "ANY", APIPath: "/api/console/knowledge-faq/list", SortNo: 1550}
+	PermissionKnowledgeFAQCreate      = Permission{Name: "创建知识FAQ", Code: "knowledgeFAQ.create", Type: "api", GroupName: "knowledgeFAQ", Method: "POST", APIPath: "/api/console/knowledge-faq/create", SortNo: 1560}
+	PermissionKnowledgeFAQUpdate      = Permission{Name: "更新知识FAQ", Code: "knowledgeFAQ.update", Type: "api", GroupName: "knowledgeFAQ", Method: "POST", APIPath: "/api/console/knowledge-faq/update", SortNo: 1570}
+	PermissionKnowledgeFAQDelete      = Permission{Name: "删除知识FAQ", Code: "knowledgeFAQ.delete", Type: "api", GroupName: "knowledgeFAQ", Method: "POST", APIPath: "/api/console/knowledge-faq/delete", SortNo: 1580}
 
 	// Skill 定义相关权限
 	PermissionSkillDefinitionView   = Permission{Name: "查看技能定义", Code: "skillDefinition.view", Type: "api", GroupName: "skillDefinition", Method: "ANY", APIPath: "/api/console/skill-definition/list", SortNo: 1610}
@@ -241,6 +245,10 @@ var Permissions = []Permission{
 	PermissionKnowledgeDocumentCreate,
 	PermissionKnowledgeDocumentUpdate,
 	PermissionKnowledgeDocumentDelete,
+	PermissionKnowledgeFAQView,
+	PermissionKnowledgeFAQCreate,
+	PermissionKnowledgeFAQUpdate,
+	PermissionKnowledgeFAQDelete,
 	PermissionSkillDefinitionView,
 	PermissionSkillDefinitionCreate,
 	PermissionSkillDefinitionUpdate,

--- a/internal/pkg/dto/request/knowledge_request.go
+++ b/internal/pkg/dto/request/knowledge_request.go
@@ -5,6 +5,7 @@ import "cs-agent/internal/pkg/enums"
 type CreateKnowledgeBaseRequest struct {
 	Name                  string  `json:"name"`
 	Description           string  `json:"description"`
+	KnowledgeType         string  `json:"knowledgeType"`
 	DefaultTopK           int     `json:"defaultTopK"`
 	DefaultScoreThreshold float64 `json:"defaultScoreThreshold"`
 	DefaultRerankLimit    int     `json:"defaultRerankLimit"`
@@ -32,6 +33,19 @@ type CreateKnowledgeDocumentRequest struct {
 type UpdateKnowledgeDocumentRequest struct {
 	ID int64 `json:"id"`
 	CreateKnowledgeDocumentRequest
+}
+
+type CreateKnowledgeFAQRequest struct {
+	KnowledgeBaseID  int64    `json:"knowledgeBaseId"`
+	Question         string   `json:"question"`
+	Answer           string   `json:"answer"`
+	SimilarQuestions []string `json:"similarQuestions"`
+	Remark           string   `json:"remark"`
+}
+
+type UpdateKnowledgeFAQRequest struct {
+	ID int64 `json:"id"`
+	CreateKnowledgeFAQRequest
 }
 
 type KnowledgeSearchRequest struct {

--- a/internal/pkg/dto/response/knowledge_response.go
+++ b/internal/pkg/dto/response/knowledge_response.go
@@ -9,6 +9,8 @@ type KnowledgeBaseResponse struct {
 	ID                    int64        `json:"id"`
 	Name                  string       `json:"name"`
 	Description           string       `json:"description"`
+	KnowledgeType         string       `json:"knowledgeType"`
+	KnowledgeTypeName     string       `json:"knowledgeTypeName"`
 	Status                enums.Status `json:"status"`
 	StatusName            string       `json:"statusName"`
 	DefaultTopK           int          `json:"defaultTopK"`
@@ -23,6 +25,7 @@ type KnowledgeBaseResponse struct {
 	FallbackMode          int          `json:"fallbackMode"`
 	FallbackModeName      string       `json:"fallbackModeName"`
 	DocumentCount         int64        `json:"documentCount"`
+	FAQCount              int64        `json:"faqCount"`
 	Remark                string       `json:"remark"`
 	CreatedAt             time.Time    `json:"createdAt"`
 	UpdatedAt             time.Time    `json:"updatedAt"`
@@ -50,11 +53,29 @@ type KnowledgeDocumentResponse struct {
 	UpdateUserName    string                             `json:"updateUserName"`
 }
 
+type KnowledgeFAQResponse struct {
+	ID                int64        `json:"id"`
+	KnowledgeBaseID   int64        `json:"knowledgeBaseId"`
+	KnowledgeBaseName string       `json:"knowledgeBaseName,omitempty"`
+	Question          string       `json:"question"`
+	Answer            string       `json:"answer"`
+	SimilarQuestions  []string     `json:"similarQuestions"`
+	Status            enums.Status `json:"status"`
+	StatusName        string       `json:"statusName"`
+	Remark            string       `json:"remark"`
+	CreatedAt         time.Time    `json:"createdAt"`
+	UpdatedAt         time.Time    `json:"updatedAt"`
+	CreateUserName    string       `json:"createUserName"`
+	UpdateUserName    string       `json:"updateUserName"`
+}
+
 type KnowledgeSearchResult struct {
 	KnowledgeBaseID int64   `json:"knowledgeBaseId"`
 	ChunkID         int64   `json:"chunkId"`
 	DocumentID      int64   `json:"documentId"`
 	DocumentTitle   string  `json:"documentTitle"`
+	FaqID           int64   `json:"faqId"`
+	FaqQuestion     string  `json:"faqQuestion"`
 	ChunkNo         int     `json:"chunkNo"`
 	Title           string  `json:"title"`
 	SectionPath     string  `json:"sectionPath"`
@@ -92,6 +113,8 @@ type KnowledgeAnswerResponse struct {
 type KnowledgeCitation struct {
 	DocumentID    int64   `json:"documentId"`
 	DocumentTitle string  `json:"documentTitle"`
+	FaqID         int64   `json:"faqId"`
+	FaqQuestion   string  `json:"faqQuestion"`
 	ChunkNo       int     `json:"chunkNo"`
 	Title         string  `json:"title"`
 	SectionPath   string  `json:"sectionPath"`
@@ -159,6 +182,8 @@ type KnowledgeRetrieveHitResponse struct {
 	ChunkID         int64     `json:"chunkId"`
 	DocumentID      int64     `json:"documentId"`
 	DocumentTitle   string    `json:"documentTitle"`
+	FaqID           int64     `json:"faqId"`
+	FaqQuestion     string    `json:"faqQuestion"`
 	ChunkNo         int       `json:"chunkNo"`
 	Title           string    `json:"title"`
 	SectionPath     string    `json:"sectionPath"`

--- a/internal/pkg/enums/knowledge.go
+++ b/internal/pkg/enums/knowledge.go
@@ -21,6 +21,22 @@ const (
 	KnowledgeDocumentContentTypeMarkdown KnowledgeDocumentContentType = "markdown"
 )
 
+type KnowledgeBaseType string
+
+const (
+	KnowledgeBaseTypeDocument KnowledgeBaseType = "document"
+	KnowledgeBaseTypeFAQ      KnowledgeBaseType = "faq"
+)
+
+var knowledgeBaseTypeLabelMap = map[KnowledgeBaseType]string{
+	KnowledgeBaseTypeDocument: "文档知识库",
+	KnowledgeBaseTypeFAQ:      "FAQ知识库",
+}
+
+func GetKnowledgeBaseTypeLabel(knowledgeType KnowledgeBaseType) string {
+	return knowledgeBaseTypeLabelMap[knowledgeType]
+}
+
 var knowledgeDocumentContentTypeLabelMap = map[KnowledgeDocumentContentType]string{
 	KnowledgeDocumentContentTypeHTML:     "HTML",
 	KnowledgeDocumentContentTypeMarkdown: "Markdown",

--- a/internal/repositories/knowledge_chunk_repository.go
+++ b/internal/repositories/knowledge_chunk_repository.go
@@ -99,14 +99,29 @@ func (r *knowledgeChunkRepository) DeleteByDocumentID(db *gorm.DB, documentID in
 	db.Delete(&models.KnowledgeChunk{}, "document_id = ?", documentID)
 }
 
+func (r *knowledgeChunkRepository) DeleteByFaqID(db *gorm.DB, faqID int64) {
+	db.Delete(&models.KnowledgeChunk{}, "faq_id = ?", faqID)
+}
+
 func (r *knowledgeChunkRepository) FindByDocumentID(db *gorm.DB, documentID int64) (list []models.KnowledgeChunk) {
 	db.Where("document_id = ?", documentID).Order("chunk_no asc").Find(&list)
+	return
+}
+
+func (r *knowledgeChunkRepository) FindByFaqID(db *gorm.DB, faqID int64) (list []models.KnowledgeChunk) {
+	db.Where("faq_id = ?", faqID).Order("chunk_no asc").Find(&list)
 	return
 }
 
 func (r *knowledgeChunkRepository) CountByDocumentID(db *gorm.DB, documentID int64) int64 {
 	var count int64
 	db.Model(&models.KnowledgeChunk{}).Where("document_id = ?", documentID).Count(&count)
+	return count
+}
+
+func (r *knowledgeChunkRepository) CountByFaqID(db *gorm.DB, faqID int64) int64 {
+	var count int64
+	db.Model(&models.KnowledgeChunk{}).Where("faq_id = ?", faqID).Count(&count)
 	return count
 }
 

--- a/internal/repositories/knowledge_faq_repository.go
+++ b/internal/repositories/knowledge_faq_repository.go
@@ -1,0 +1,63 @@
+package repositories
+
+import (
+	"cs-agent/internal/models"
+
+	"github.com/mlogclub/simple/sqls"
+	"github.com/mlogclub/simple/web/params"
+	"gorm.io/gorm"
+)
+
+var KnowledgeFAQRepository = newKnowledgeFAQRepository()
+
+func newKnowledgeFAQRepository() *knowledgeFAQRepository {
+	return &knowledgeFAQRepository{}
+}
+
+type knowledgeFAQRepository struct{}
+
+func (r *knowledgeFAQRepository) Get(db *gorm.DB, id int64) *models.KnowledgeFAQ {
+	ret := &models.KnowledgeFAQ{}
+	if err := db.First(ret, "id = ?", id).Error; err != nil {
+		return nil
+	}
+	return ret
+}
+
+func (r *knowledgeFAQRepository) Find(db *gorm.DB, cnd *sqls.Cnd) (list []models.KnowledgeFAQ) {
+	cnd.Find(db, &list)
+	return
+}
+
+func (r *knowledgeFAQRepository) FindPageByCnd(db *gorm.DB, cnd *sqls.Cnd) (list []models.KnowledgeFAQ, paging *sqls.Paging) {
+	cnd.Find(db, &list)
+	count := cnd.Count(db, &models.KnowledgeFAQ{})
+	paging = &sqls.Paging{
+		Page:  cnd.Paging.Page,
+		Limit: cnd.Paging.Limit,
+		Total: count,
+	}
+	return
+}
+
+func (r *knowledgeFAQRepository) FindPageByParams(db *gorm.DB, queryParams *params.QueryParams) (list []models.KnowledgeFAQ, paging *sqls.Paging) {
+	return r.FindPageByCnd(db, &queryParams.Cnd)
+}
+
+func (r *knowledgeFAQRepository) Create(db *gorm.DB, t *models.KnowledgeFAQ) error {
+	return db.Create(t).Error
+}
+
+func (r *knowledgeFAQRepository) Updates(db *gorm.DB, id int64, columns map[string]any) error {
+	return db.Model(&models.KnowledgeFAQ{}).Where("id = ?", id).Updates(columns).Error
+}
+
+func (r *knowledgeFAQRepository) Delete(db *gorm.DB, id int64) {
+	db.Delete(&models.KnowledgeFAQ{}, "id = ?", id)
+}
+
+func (r *knowledgeFAQRepository) CountByKnowledgeBaseID(db *gorm.DB, knowledgeBaseID int64) int64 {
+	var count int64
+	db.Model(&models.KnowledgeFAQ{}).Where("knowledge_base_id = ?", knowledgeBaseID).Count(&count)
+	return count
+}

--- a/internal/services/knowledge_base_service.go
+++ b/internal/services/knowledge_base_service.go
@@ -103,6 +103,7 @@ func (s *knowledgeBaseService) UpdateKnowledgeBase(req request.UpdateKnowledgeBa
 	return repositories.KnowledgeBaseRepository.Updates(sqls.DB(), req.ID, map[string]any{
 		"name":                    item.Name,
 		"description":             item.Description,
+		"knowledge_type":          item.KnowledgeType,
 		"default_top_k":           item.DefaultTopK,
 		"default_score_threshold": item.DefaultScoreThreshold,
 		"default_rerank_limit":    item.DefaultRerankLimit,
@@ -128,6 +129,10 @@ func (s *knowledgeBaseService) DeleteKnowledgeBase(id int64) error {
 	if docCount > 0 {
 		return errorsx.InvalidParam("知识库下存在文档，无法删除")
 	}
+	faqCount := repositories.KnowledgeFAQRepository.CountByKnowledgeBaseID(sqls.DB(), id)
+	if faqCount > 0 {
+		return errorsx.InvalidParam("知识库下存在FAQ，无法删除")
+	}
 	repositories.KnowledgeBaseRepository.Delete(sqls.DB(), id)
 	return nil
 }
@@ -147,6 +152,7 @@ func (s *knowledgeBaseService) buildKnowledgeBaseModel(req request.CreateKnowled
 	item := &models.KnowledgeBase{
 		Name:                  req.Name,
 		Description:           req.Description,
+		KnowledgeType:         req.KnowledgeType,
 		DefaultTopK:           req.DefaultTopK,
 		DefaultScoreThreshold: req.DefaultScoreThreshold,
 		DefaultRerankLimit:    req.DefaultRerankLimit,
@@ -161,6 +167,12 @@ func (s *knowledgeBaseService) buildKnowledgeBaseModel(req request.CreateKnowled
 	if item.DefaultTopK == 0 {
 		item.DefaultTopK = 10
 	}
+	if item.KnowledgeType == "" {
+		item.KnowledgeType = string(enums.KnowledgeBaseTypeDocument)
+	}
+	if !isValidKnowledgeType(item.KnowledgeType) {
+		return nil, errorsx.InvalidParam("知识库类型不支持")
+	}
 	if item.DefaultScoreThreshold == 0 {
 		item.DefaultScoreThreshold = 0.2
 	}
@@ -170,19 +182,27 @@ func (s *knowledgeBaseService) buildKnowledgeBaseModel(req request.CreateKnowled
 	if item.ChunkProvider == "" {
 		item.ChunkProvider = string(enums.KnowledgeChunkProviderStructured)
 	}
+	if item.KnowledgeType == string(enums.KnowledgeBaseTypeFAQ) {
+		item.ChunkProvider = string(enums.KnowledgeChunkProviderFAQ)
+		item.ChunkTargetTokens = 0
+		item.ChunkMaxTokens = 0
+		item.ChunkOverlapTokens = 0
+	} else if item.ChunkProvider == string(enums.KnowledgeChunkProviderFAQ) {
+		return nil, errorsx.InvalidParam("文档知识库不能使用FAQ分块策略")
+	}
 	if !isValidChunkProvider(item.ChunkProvider) {
 		return nil, errorsx.InvalidParam("分块策略不支持")
 	}
-	if item.ChunkTargetTokens == 0 {
+	if item.KnowledgeType != string(enums.KnowledgeBaseTypeFAQ) && item.ChunkTargetTokens == 0 {
 		item.ChunkTargetTokens = 300
 	}
-	if item.ChunkMaxTokens == 0 {
+	if item.KnowledgeType != string(enums.KnowledgeBaseTypeFAQ) && item.ChunkMaxTokens == 0 {
 		item.ChunkMaxTokens = 400
 	}
-	if item.ChunkMaxTokens < item.ChunkTargetTokens {
+	if item.KnowledgeType != string(enums.KnowledgeBaseTypeFAQ) && item.ChunkMaxTokens < item.ChunkTargetTokens {
 		item.ChunkMaxTokens = item.ChunkTargetTokens
 	}
-	if item.ChunkOverlapTokens == 0 {
+	if item.KnowledgeType != string(enums.KnowledgeBaseTypeFAQ) && item.ChunkOverlapTokens == 0 {
 		item.ChunkOverlapTokens = 40
 	}
 	if item.AnswerMode == 0 {
@@ -200,6 +220,15 @@ func isValidChunkProvider(provider string) bool {
 		string(enums.KnowledgeChunkProviderStructured),
 		string(enums.KnowledgeChunkProviderFAQ),
 		string(enums.KnowledgeChunkProviderSemantic):
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidKnowledgeType(knowledgeType string) bool {
+	switch knowledgeType {
+	case string(enums.KnowledgeBaseTypeDocument), string(enums.KnowledgeBaseTypeFAQ):
 		return true
 	default:
 		return false

--- a/internal/services/knowledge_document_service.go
+++ b/internal/services/knowledge_document_service.go
@@ -86,6 +86,9 @@ func (s *knowledgeDocumentService) CreateKnowledgeDocument(req request.CreateKno
 	if kb == nil {
 		return nil, errorsx.InvalidParam("知识库不存在")
 	}
+	if kb.KnowledgeType == string(enums.KnowledgeBaseTypeFAQ) {
+		return nil, errorsx.InvalidParam("FAQ知识库不支持文档")
+	}
 	item, err := s.buildKnowledgeDocumentModel(req)
 	if err != nil {
 		return nil, err
@@ -121,6 +124,9 @@ func (s *knowledgeDocumentService) UpdateKnowledgeDocument(req request.UpdateKno
 	kb := KnowledgeBaseService.Get(req.KnowledgeBaseID)
 	if kb == nil {
 		return errorsx.InvalidParam("知识库不存在")
+	}
+	if kb.KnowledgeType == string(enums.KnowledgeBaseTypeFAQ) {
+		return errorsx.InvalidParam("FAQ知识库不支持文档")
 	}
 	item, err := s.buildKnowledgeDocumentModel(req.CreateKnowledgeDocumentRequest)
 	if err != nil {

--- a/internal/services/knowledge_faq_service.go
+++ b/internal/services/knowledge_faq_service.go
@@ -1,0 +1,160 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"cs-agent/internal/ai/rag"
+	"cs-agent/internal/models"
+	"cs-agent/internal/pkg/dto"
+	"cs-agent/internal/pkg/dto/request"
+	"cs-agent/internal/pkg/errorsx"
+	"cs-agent/internal/pkg/utils"
+	"cs-agent/internal/repositories"
+
+	"github.com/mlogclub/simple/sqls"
+	"github.com/mlogclub/simple/web/params"
+)
+
+var KnowledgeFAQService = newKnowledgeFAQService()
+
+func newKnowledgeFAQService() *knowledgeFAQService {
+	return &knowledgeFAQService{}
+}
+
+type knowledgeFAQService struct{}
+
+func (s *knowledgeFAQService) Get(id int64) *models.KnowledgeFAQ {
+	return repositories.KnowledgeFAQRepository.Get(sqls.DB(), id)
+}
+
+func (s *knowledgeFAQService) FindPageByCnd(cnd *sqls.Cnd) (list []models.KnowledgeFAQ, paging *sqls.Paging) {
+	return repositories.KnowledgeFAQRepository.FindPageByCnd(sqls.DB(), cnd)
+}
+
+func (s *knowledgeFAQService) FindPageByParams(queryParams *params.QueryParams) (list []models.KnowledgeFAQ, paging *sqls.Paging) {
+	return repositories.KnowledgeFAQRepository.FindPageByParams(sqls.DB(), queryParams)
+}
+
+func (s *knowledgeFAQService) CreateKnowledgeFAQ(req request.CreateKnowledgeFAQRequest, operator *dto.AuthPrincipal) (*models.KnowledgeFAQ, error) {
+	if operator == nil {
+		return nil, errorsx.Unauthorized("未登录或登录已过期")
+	}
+	kb, err := s.requireFAQKnowledgeBase(req.KnowledgeBaseID)
+	if err != nil {
+		return nil, err
+	}
+	item, err := s.buildKnowledgeFAQModel(req)
+	if err != nil {
+		return nil, err
+	}
+	item.Status = kb.Status
+	item.AuditFields = utils.BuildAuditFields(operator)
+	if err := repositories.KnowledgeFAQRepository.Create(sqls.DB(), item); err != nil {
+		return nil, err
+	}
+	if err := rag.Index.IndexFAQByID(context.Background(), item.ID); err != nil {
+		slog.Error("failed to index created knowledge faq", "faq_id", item.ID, "error", err)
+		return item, nil
+	}
+	return s.Get(item.ID), nil
+}
+
+func (s *knowledgeFAQService) UpdateKnowledgeFAQ(req request.UpdateKnowledgeFAQRequest, operator *dto.AuthPrincipal) error {
+	if operator == nil {
+		return errorsx.Unauthorized("未登录或登录已过期")
+	}
+	current := s.Get(req.ID)
+	if current == nil {
+		return errorsx.InvalidParam("FAQ不存在")
+	}
+	if _, err := s.requireFAQKnowledgeBase(req.KnowledgeBaseID); err != nil {
+		return err
+	}
+	item, err := s.buildKnowledgeFAQModel(req.CreateKnowledgeFAQRequest)
+	if err != nil {
+		return err
+	}
+	if err := repositories.KnowledgeFAQRepository.Updates(sqls.DB(), req.ID, map[string]any{
+		"knowledge_base_id": item.KnowledgeBaseID,
+		"question":          item.Question,
+		"answer":            item.Answer,
+		"similar_questions": item.SimilarQuestions,
+		"remark":            item.Remark,
+		"update_user_id":    operator.UserID,
+		"update_user_name":  operator.Username,
+		"updated_at":        time.Now(),
+	}); err != nil {
+		return err
+	}
+	return rag.Index.IndexFAQByID(context.Background(), req.ID)
+}
+
+func (s *knowledgeFAQService) DeleteKnowledgeFAQ(id int64) error {
+	current := s.Get(id)
+	if current == nil {
+		return errorsx.InvalidParam("FAQ不存在")
+	}
+	chunks := repositories.KnowledgeChunkRepository.FindByFaqID(sqls.DB(), id)
+	if err := sqls.WithTransaction(func(ctx *sqls.TxContext) error {
+		ctx.Tx.Delete(&models.KnowledgeFAQ{}, "id = ?", id)
+		ctx.Tx.Delete(&models.KnowledgeChunk{}, "faq_id = ?", id)
+		return nil
+	}); err != nil {
+		return err
+	}
+	return rag.Index.RemoveFAQIndexByChunkModels(context.Background(), current.KnowledgeBaseID, id, chunks)
+}
+
+func (s *knowledgeFAQService) buildKnowledgeFAQModel(req request.CreateKnowledgeFAQRequest) (*models.KnowledgeFAQ, error) {
+	if req.KnowledgeBaseID <= 0 {
+		return nil, errorsx.InvalidParam("知识库不存在")
+	}
+	if req.Question == "" {
+		return nil, errorsx.InvalidParam("问题不能为空")
+	}
+	if req.Answer == "" {
+		return nil, errorsx.InvalidParam("答案不能为空")
+	}
+	similarQuestions, err := json.Marshal(normalizeSimilarQuestions(req.SimilarQuestions))
+	if err != nil {
+		return nil, errorsx.InvalidParam("相似问格式不合法")
+	}
+	return &models.KnowledgeFAQ{
+		KnowledgeBaseID:  req.KnowledgeBaseID,
+		Question:         req.Question,
+		Answer:           req.Answer,
+		SimilarQuestions: string(similarQuestions),
+		Remark:           req.Remark,
+	}, nil
+}
+
+func (s *knowledgeFAQService) requireFAQKnowledgeBase(knowledgeBaseID int64) (*models.KnowledgeBase, error) {
+	kb := KnowledgeBaseService.Get(knowledgeBaseID)
+	if kb == nil {
+		return nil, errorsx.InvalidParam("知识库不存在")
+	}
+	if kb.KnowledgeType != "faq" {
+		return nil, errorsx.InvalidParam("当前知识库不是FAQ知识库")
+	}
+	return kb, nil
+}
+
+func normalizeSimilarQuestions(values []string) []string {
+	items := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, item := range values {
+		value := item
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		items = append(items, value)
+	}
+	return items
+}

--- a/web/app/(console)/knowledge/_components/debug-panel.tsx
+++ b/web/app/(console)/knowledge/_components/debug-panel.tsx
@@ -201,7 +201,7 @@ export function DebugPanel({ knowledgeBaseId }: DebugPanelProps) {
                       >
                         <div className="flex items-center justify-between gap-2">
                           <div className="truncate text-xs font-medium">
-                            {citation.documentTitle || `文档 ${citation.documentId}`}
+                            {getSearchResultLabel(citation)}
                           </div>
                           <Badge variant="outline">{citation.score.toFixed(4)}</Badge>
                         </div>
@@ -232,7 +232,7 @@ export function DebugPanel({ knowledgeBaseId }: DebugPanelProps) {
                   <div key={`${item.chunkId}-${item.documentId}`} className="rounded-md border bg-background p-3">
                     <div className="flex items-center justify-between gap-2">
                       <div className="truncate text-sm font-medium">
-                        {item.documentTitle || `文档 ${item.documentId}`}
+                        {getSearchResultLabel(item)}
                       </div>
                       <Badge variant="outline">{item.score.toFixed(4)}</Badge>
                     </div>
@@ -277,7 +277,7 @@ export function DebugPanel({ knowledgeBaseId }: DebugPanelProps) {
                         <div key={`${provider.provider}-${item.documentId}-${item.chunkNo}`} className="rounded border p-2">
                           <div className="flex items-center justify-between gap-2">
                             <div className="truncate text-xs font-medium">
-                              {item.documentTitle || `文档 ${item.documentId}`}
+                              {getSearchResultLabel(item)}
                             </div>
                             <Badge variant="outline">{item.score.toFixed(4)}</Badge>
                           </div>
@@ -307,4 +307,22 @@ function parseExpectedDocIds(value: string): number[] | undefined {
     .map((item) => Number(item.trim()))
     .filter((item) => Number.isFinite(item) && item > 0)
   return ids.length > 0 ? ids : undefined
+}
+
+function getSearchResultLabel(item: {
+  faqQuestion?: string
+  faqId?: number
+  documentTitle?: string
+  documentId?: number
+}) {
+  if (item.faqQuestion) {
+    return item.faqQuestion
+  }
+  if (item.documentTitle) {
+    return item.documentTitle
+  }
+  if (item.faqId && item.faqId > 0) {
+    return `FAQ ${item.faqId}`
+  }
+  return `文档 ${item.documentId ?? 0}`
 }

--- a/web/app/(console)/knowledge/_components/faq-edit.tsx
+++ b/web/app/(console)/knowledge/_components/faq-edit.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, type Resolver } from "react-hook-form";
+import { z } from "zod/v4";
+
+import { ProjectDialog } from "@/components/project-dialog";
+import { Button } from "@/components/ui/button";
+import { Field, FieldContent, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  fetchKnowledgeFAQ,
+  type CreateKnowledgeFAQPayload,
+  type KnowledgeFAQ,
+} from "@/lib/api/admin";
+
+type FAQEditDialogProps = {
+  open: boolean;
+  saving: boolean;
+  itemId: number | null;
+  knowledgeBaseId: number | null;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (payload: CreateKnowledgeFAQPayload) => Promise<void>;
+};
+
+const formSchema = z.object({
+  question: z.string().trim().min(1, "问题不能为空").max(500, "问题最多500个字符"),
+  answer: z.string().trim().min(1, "答案不能为空"),
+  similarQuestionsText: z.string(),
+  remark: z.string().trim().max(500, "备注最多500个字符"),
+});
+
+type EditForm = z.infer<typeof formSchema>;
+
+const resolver = zodResolver(formSchema as never) as Resolver<
+  z.input<typeof formSchema>,
+  undefined,
+  z.output<typeof formSchema>
+>;
+
+const emptyForm: EditForm = {
+  question: "",
+  answer: "",
+  similarQuestionsText: "",
+  remark: "",
+};
+
+function buildForm(item: KnowledgeFAQ | null): EditForm {
+  if (!item) {
+    return emptyForm;
+  }
+  return {
+    question: item.question,
+    answer: item.answer,
+    similarQuestionsText: (item.similarQuestions ?? []).join("\n"),
+    remark: item.remark ?? "",
+  };
+}
+
+function buildPayload(form: EditForm, knowledgeBaseId: number): CreateKnowledgeFAQPayload {
+  return {
+    knowledgeBaseId,
+    question: form.question.trim(),
+    answer: form.answer.trim(),
+    similarQuestions: form.similarQuestionsText
+      .split("\n")
+      .map((item) => item.trim())
+      .filter(Boolean),
+    remark: form.remark.trim(),
+  };
+}
+
+export function FAQEditDialog({
+  open,
+  saving,
+  itemId,
+  knowledgeBaseId,
+  onOpenChange,
+  onSubmit,
+}: FAQEditDialogProps) {
+  if (!open || !knowledgeBaseId) {
+    return null;
+  }
+  return (
+    <FAQEditDialogBody
+      key={itemId ? `edit-${itemId}` : "create"}
+      open={open}
+      saving={saving}
+      itemId={itemId}
+      knowledgeBaseId={knowledgeBaseId}
+      onOpenChange={onOpenChange}
+      onSubmit={onSubmit}
+    />
+  );
+}
+
+type FAQEditDialogBodyProps = {
+  open: boolean;
+  saving: boolean;
+  itemId: number | null;
+  knowledgeBaseId: number;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (payload: CreateKnowledgeFAQPayload) => Promise<void>;
+};
+
+function FAQEditDialogBody({
+  open,
+  saving,
+  itemId,
+  knowledgeBaseId,
+  onOpenChange,
+  onSubmit,
+}: FAQEditDialogBodyProps) {
+  const [loading, setLoading] = useState(false);
+  const formId = "knowledge-faq-edit-form";
+  const form = useForm<
+    z.input<typeof formSchema>,
+    undefined,
+    z.output<typeof formSchema>
+  >({
+    resolver,
+    defaultValues: emptyForm,
+  });
+  const {
+    handleSubmit,
+    reset,
+    register,
+    formState: { errors },
+  } = form;
+
+  useEffect(() => {
+    async function loadDetail() {
+      if (!itemId) {
+        reset(emptyForm);
+        return;
+      }
+      setLoading(true);
+      try {
+        const data = await fetchKnowledgeFAQ(itemId);
+        reset(buildForm(data));
+      } finally {
+        setLoading(false);
+      }
+    }
+    if (open) {
+      void loadDetail();
+    }
+  }, [itemId, open, reset]);
+
+  async function onFormSubmit(values: EditForm) {
+    await onSubmit(buildPayload(values, knowledgeBaseId));
+  }
+
+  return (
+    <ProjectDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={itemId ? "编辑FAQ" : "新建FAQ"}
+      size="lg"
+      footer={
+        <>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            取消
+          </Button>
+          <Button type="submit" form={formId} disabled={saving || loading}>
+            {saving ? "保存中..." : itemId ? "保存" : "创建"}
+          </Button>
+        </>
+      }
+    >
+      {loading ? (
+        <div className="flex items-center justify-center py-12 text-muted-foreground">加载中...</div>
+      ) : (
+        <form id={formId} onSubmit={handleSubmit(onFormSubmit)} className="space-y-4">
+          <Field data-invalid={!!errors.question}>
+            <FieldLabel htmlFor="faq-question">标准问题</FieldLabel>
+            <FieldContent>
+              <Input id="faq-question" placeholder="请输入标准问题" {...register("question")} />
+              <FieldError errors={[errors.question]} />
+            </FieldContent>
+          </Field>
+
+          <Field data-invalid={!!errors.answer}>
+            <FieldLabel htmlFor="faq-answer">答案</FieldLabel>
+            <FieldContent>
+              <Textarea id="faq-answer" rows={8} placeholder="请输入FAQ答案" {...register("answer")} />
+              <FieldError errors={[errors.answer]} />
+            </FieldContent>
+          </Field>
+
+          <Field>
+            <FieldLabel htmlFor="faq-similar-questions">相似问</FieldLabel>
+            <FieldContent>
+              <Textarea
+                id="faq-similar-questions"
+                rows={5}
+                placeholder={"一行一个相似问"}
+                {...register("similarQuestionsText")}
+              />
+            </FieldContent>
+          </Field>
+
+          <Field data-invalid={!!errors.remark}>
+            <FieldLabel htmlFor="faq-remark">备注</FieldLabel>
+            <FieldContent>
+              <Textarea id="faq-remark" rows={3} placeholder="备注" {...register("remark")} />
+              <FieldError errors={[errors.remark]} />
+            </FieldContent>
+          </Field>
+        </form>
+      )}
+    </ProjectDialog>
+  );
+}
+

--- a/web/app/(console)/knowledge/_components/faq-list.tsx
+++ b/web/app/(console)/knowledge/_components/faq-list.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { ListPagination } from "@/components/list-pagination";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  createKnowledgeFAQ,
+  deleteKnowledgeFAQ,
+  fetchKnowledgeFAQs,
+  updateKnowledgeFAQ,
+  type CreateKnowledgeFAQPayload,
+  type KnowledgeFAQ,
+  type PageResult,
+} from "@/lib/api/admin";
+import { formatDateTime } from "@/lib/utils";
+import { FAQEditDialog } from "./faq-edit";
+
+type FAQListProps = {
+  knowledgeBaseId: number | null;
+  onActionStateChange?: (state: FAQListActionState) => void;
+};
+
+export type FAQListActionState = {
+  onRefresh: () => void;
+  onCreate: () => void;
+  loading: boolean;
+};
+
+export function FAQList({ knowledgeBaseId, onActionStateChange }: FAQListProps) {
+  const [keywordInput, setKeywordInput] = useState("");
+  const [keyword, setKeyword] = useState("");
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(20);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingItem, setEditingItem] = useState<KnowledgeFAQ | null>(null);
+  const [result, setResult] = useState<PageResult<KnowledgeFAQ>>({
+    results: [],
+    page: { page: 1, limit: 20, total: 0 },
+  });
+
+  const loadData = useCallback(async () => {
+    if (!knowledgeBaseId) {
+      setResult({
+        results: [],
+        page: { page: 1, limit: 20, total: 0 },
+      });
+      return;
+    }
+    setLoading(true);
+    try {
+      const data = await fetchKnowledgeFAQs({
+        knowledgeBaseId,
+        question: keyword.trim() || undefined,
+        page,
+        limit,
+      });
+      setResult(data);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "加载FAQ失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [keyword, knowledgeBaseId, limit, page]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  useEffect(() => {
+    onActionStateChange?.({
+      onRefresh: () => void loadData(),
+      onCreate: () => {
+        setEditingItem(null);
+        setDialogOpen(true);
+      },
+      loading,
+    });
+  }, [loadData, loading, onActionStateChange]);
+
+  async function handleSubmit(payload: CreateKnowledgeFAQPayload) {
+    setSaving(true);
+    try {
+      if (editingItem) {
+        await updateKnowledgeFAQ({ id: editingItem.id, ...payload });
+      } else {
+        await createKnowledgeFAQ(payload);
+      }
+      setDialogOpen(false);
+      setEditingItem(null);
+      await loadData();
+      toast.success("FAQ已保存");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "保存FAQ失败");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(item: KnowledgeFAQ) {
+    try {
+      await deleteKnowledgeFAQ(item.id);
+      toast.success("FAQ已删除");
+      await loadData();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "删除FAQ失败");
+    }
+  }
+
+  if (!knowledgeBaseId) {
+    return <div className="flex h-full items-center justify-center text-sm text-muted-foreground">请选择一个FAQ知识库查看FAQ</div>;
+  }
+
+  return (
+    <>
+      <div className="flex h-full flex-col gap-4 p-4">
+        <div className="flex items-center gap-2">
+          <div className="relative max-w-md flex-1">
+            <SearchIcon className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={keywordInput}
+              onChange={(event) => setKeywordInput(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  setKeyword(keywordInput);
+                  setPage(1);
+                }
+              }}
+              placeholder="按问题搜索FAQ"
+              className="pl-9"
+            />
+          </div>
+          <Button
+            variant="outline"
+            onClick={() => {
+              setKeyword(keywordInput);
+              setPage(1);
+            }}
+            disabled={loading}
+          >
+            查询
+          </Button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>问题</TableHead>
+                <TableHead>相似问</TableHead>
+                <TableHead>更新时间</TableHead>
+                <TableHead className="w-[80px] text-right">操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {result.results.map((item) => (
+                <TableRow key={item.id}>
+                  <TableCell>
+                    <div className="font-medium">{item.question}</div>
+                    <div className="mt-1 line-clamp-2 text-sm text-muted-foreground">{item.answer}</div>
+                  </TableCell>
+                  <TableCell>{item.similarQuestions.length}</TableCell>
+                  <TableCell>{formatDateTime(item.updatedAt)}</TableCell>
+                  <TableCell className="text-right">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" size="icon">
+                          <MoreHorizontalIcon className="size-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          onClick={() => {
+                            setEditingItem(item);
+                            setDialogOpen(true);
+                          }}
+                        >
+                          <PencilIcon className="mr-2 size-4" />
+                          编辑
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          className="text-destructive focus:text-destructive"
+                          onClick={() => void handleDelete(item)}
+                        >
+                          <Trash2Icon className="mr-2 size-4" />
+                          删除
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {!loading && result.results.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="py-12 text-center text-sm text-muted-foreground">
+                    当前知识库还没有FAQ
+                  </TableCell>
+                </TableRow>
+              ) : null}
+            </TableBody>
+          </Table>
+        </div>
+
+        <ListPagination
+          page={result.page.page}
+          pageSize={result.page.limit}
+          total={result.page.total}
+          onPageChange={setPage}
+          onPageSizeChange={(next) => {
+            setLimit(next);
+            setPage(1);
+          }}
+        />
+      </div>
+
+      <FAQEditDialog
+        open={dialogOpen}
+        saving={saving}
+        itemId={editingItem?.id ?? null}
+        knowledgeBaseId={knowledgeBaseId}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditingItem(null);
+          }
+          setDialogOpen(open);
+        }}
+        onSubmit={handleSubmit}
+      />
+    </>
+  );
+}
+

--- a/web/app/(console)/knowledge/_components/knowledge-base-edit.tsx
+++ b/web/app/(console)/knowledge/_components/knowledge-base-edit.tsx
@@ -15,13 +15,6 @@ import {
   FieldLabel,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import {
   fetchKnowledgeBase,
@@ -29,6 +22,8 @@ import {
   type KnowledgeBase,
 } from "@/lib/api/admin";
 import {
+  KnowledgeBaseType,
+  KnowledgeBaseTypeLabels,
   KnowledgeChunkProvider,
   KnowledgeChunkProviderLabels,
   KnowledgeAnswerMode,
@@ -36,7 +31,7 @@ import {
   KnowledgeFallbackMode,
   KnowledgeFallbackModeLabels,
 } from "@/lib/generated/enums";
-import { getEnumLabel, getEnumOptions } from "@/lib/enums";
+import { getEnumOptions } from "@/lib/enums";
 
 type KnowledgeBaseEditDialogProps = {
   open: boolean;
@@ -49,6 +44,7 @@ type KnowledgeBaseEditDialogProps = {
 const emptyForm: EditForm = {
   name: "",
   description: "",
+  knowledgeType: KnowledgeBaseType.Document,
   defaultTopK: "5",
   defaultScoreThreshold: "0.2",
   defaultRerankLimit: "10",
@@ -64,6 +60,7 @@ const emptyForm: EditForm = {
 const knowledgeBaseFormSchema = z.object({
   name: z.string().trim().min(1, "名称不能为空").max(100, "名称最多100个字符"),
   description: z.string().trim().max(500, "描述最多500个字符"),
+  knowledgeType: z.string().trim().min(1, "请选择知识库类型"),
   defaultTopK: z.string().trim().min(1, "请输入TopK值"),
   defaultScoreThreshold: z.string().trim().min(1, "请输入分数阈值"),
   defaultRerankLimit: z.string().trim().min(1, "请输入重排序限制"),
@@ -93,6 +90,7 @@ function buildForm(item: KnowledgeBase | null): EditForm {
   return {
     name: item.name,
     description: item.description || "",
+    knowledgeType: item.knowledgeType || KnowledgeBaseType.Document,
     defaultTopK: String(item.defaultTopK),
     defaultScoreThreshold: String(item.defaultScoreThreshold),
     defaultRerankLimit: String(item.defaultRerankLimit),
@@ -110,6 +108,7 @@ function buildPayload(form: EditForm): CreateKnowledgeBasePayload {
   return {
     name: form.name.trim(),
     description: form.description.trim(),
+    knowledgeType: form.knowledgeType,
     defaultTopK: Number(form.defaultTopK),
     defaultScoreThreshold: Number(form.defaultScoreThreshold),
     defaultRerankLimit: Number(form.defaultRerankLimit),
@@ -176,8 +175,11 @@ function KnowledgeBaseFormDialogBody({
     handleSubmit,
     reset,
     register,
+    watch,
     formState: { errors },
   } = form;
+  const knowledgeType = watch("knowledgeType");
+  const isFAQKnowledgeBase = knowledgeType === KnowledgeBaseType.FAQ;
 
   useEffect(() => {
     if (!open) {
@@ -280,7 +282,32 @@ function KnowledgeBaseFormDialogBody({
             </FieldContent>
           </Field>
 
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
+          <Field data-invalid={!!errors.knowledgeType}>
+            <FieldLabel htmlFor="kb-knowledge-type">知识库类型</FieldLabel>
+            <FieldContent>
+              <Controller
+                control={control}
+                name="knowledgeType"
+                render={({ field }) => (
+                  <OptionCombobox
+                    value={field.value}
+                    options={getEnumOptions(KnowledgeBaseTypeLabels).map((option) => ({
+                      value: String(option.value),
+                      label: option.label,
+                    }))}
+                    placeholder="选择知识库类型"
+                    searchPlaceholder="搜索知识库类型"
+                    emptyText="没有匹配的知识库类型"
+                    onChange={field.onChange}
+                  />
+                )}
+              />
+              <FieldError errors={[errors.knowledgeType]} />
+            </FieldContent>
+          </Field>
+
+          {!isFAQKnowledgeBase ? (
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
             <Field data-invalid={!!errors.chunkProvider}>
               <FieldLabel htmlFor="kb-chunk-provider">分块策略</FieldLabel>
               <FieldContent>
@@ -290,12 +317,12 @@ function KnowledgeBaseFormDialogBody({
                   render={({ field }) => (
                     <OptionCombobox
                       value={field.value}
-                      options={getEnumOptions(KnowledgeChunkProviderLabels).map(
-                        (option) => ({
+                      options={getEnumOptions(KnowledgeChunkProviderLabels)
+                        .filter((option) => option.value !== KnowledgeChunkProvider.FAQ)
+                        .map((option) => ({
                           value: String(option.value),
                           label: option.label,
-                        }),
-                      )}
+                        }))}
                       placeholder="选择分块策略"
                       searchPlaceholder="搜索分块策略"
                       emptyText="没有匹配的分块策略"
@@ -352,7 +379,8 @@ function KnowledgeBaseFormDialogBody({
                 <FieldError errors={[errors.chunkOverlapTokens]} />
               </FieldContent>
             </Field>
-          </div>
+            </div>
+          ) : null}
 
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
             <Field data-invalid={!!errors.defaultTopK}>

--- a/web/app/(console)/knowledge/_components/knowledge-base-list.tsx
+++ b/web/app/(console)/knowledge/_components/knowledge-base-list.tsx
@@ -143,7 +143,7 @@ function SortableKnowledgeBaseCard({
         <FolderIcon className="size-4 shrink-0 text-muted-foreground" />
         <span className="min-w-0 flex-1 truncate">{item.name}</span>
         <span className="shrink-0 text-xs text-muted-foreground">
-          {item.documentCount}
+          {item.knowledgeType === "faq" ? item.faqCount : item.documentCount}
         </span>
         <DropdownMenu>
           <DropdownMenuTrigger

--- a/web/app/(console)/knowledge/_components/retrieve-log-detail.tsx
+++ b/web/app/(console)/knowledge/_components/retrieve-log-detail.tsx
@@ -47,7 +47,7 @@ function CitationList({ hits }: { hits: KnowledgeRetrieveHit[] }) {
       {citations.map((item) => (
         <div key={item.id} className="rounded-lg border p-3">
           <div className="flex items-center gap-2">
-            <span className="font-medium">{item.documentTitle || `文档 #${item.documentId}`}</span>
+            <span className="font-medium">{getHitSourceLabel(item)}</span>
             <Badge variant="outline">Chunk #{item.chunkNo}</Badge>
           </div>
           <div className="mt-1 text-xs text-muted-foreground">
@@ -193,7 +193,7 @@ export function RetrieveLogDetailDrawer({
                     <div key={item.id} className="rounded-lg border p-3">
                       <div className="flex flex-wrap items-center gap-2">
                         <Badge variant="outline">#{item.rankNo}</Badge>
-                        <span className="font-medium">{item.documentTitle || `文档 #${item.documentId}`}</span>
+                        <span className="font-medium">{getHitSourceLabel(item)}</span>
                         <Badge variant={item.usedInAnswer ? "default" : "secondary"}>
                           {item.usedInAnswer ? "已入上下文" : "未入上下文"}
                         </Badge>
@@ -229,6 +229,19 @@ export function RetrieveLogDetailDrawer({
       </DrawerContent>
     </Drawer>
   )
+}
+
+function getHitSourceLabel(item: KnowledgeRetrieveHit) {
+  if (item.faqQuestion) {
+    return item.faqQuestion
+  }
+  if (item.documentTitle) {
+    return item.documentTitle
+  }
+  if (item.faqId > 0) {
+    return `FAQ #${item.faqId}`
+  }
+  return `文档 #${item.documentId}`
 }
 
 function Metric({

--- a/web/app/(console)/knowledge/page.tsx
+++ b/web/app/(console)/knowledge/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { KnowledgeBaseList } from "./_components/knowledge-base-list"
 import { DebugPanel } from "./_components/debug-panel"
 import { DocumentList, type DocumentListActionState } from "./_components/document-list"
+import { FAQList, type FAQListActionState } from "./_components/faq-list"
 import { RetrieveLogList } from "./_components/retrieve-log-list"
 import { Button } from "@/components/ui/button"
 import {
@@ -31,6 +32,8 @@ export default function DashboardKnowledgeDocumentsPage() {
   const [debugPanelOpen, setDebugPanelOpen] = useState(false)
   const [activeTab, setActiveTab] = useState("documents")
   const [documentActionState, setDocumentActionState] = useState<DocumentListActionState | null>(null)
+  const [faqActionState, setFAQActionState] = useState<FAQListActionState | null>(null)
+  const isFAQKnowledgeBase = selectedKnowledgeBase?.knowledgeType === "faq"
 
   return (
     <div className="flex h-[calc(100vh-4rem)]">
@@ -64,10 +67,10 @@ export default function DashboardKnowledgeDocumentsPage() {
           <div className="border-b px-6 py-4">
             <div className="flex items-center gap-2">
               <TabsList>
-                <TabsTrigger value="documents">文档</TabsTrigger>
+                <TabsTrigger value="documents">{isFAQKnowledgeBase ? "FAQ" : "文档"}</TabsTrigger>
                 <TabsTrigger value="retrieveLogs">检索日志</TabsTrigger>
               </TabsList>
-              {activeTab === "documents" && documentActionState ? (
+              {activeTab === "documents" && !isFAQKnowledgeBase && documentActionState ? (
                 <div className="ml-auto flex items-center gap-1">
                   <Button
                     variant="ghost"
@@ -117,13 +120,52 @@ export default function DashboardKnowledgeDocumentsPage() {
                   </Button>
                 </div>
               ) : null}
+              {activeTab === "documents" && isFAQKnowledgeBase && faqActionState ? (
+                <div className="ml-auto flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7"
+                    onClick={faqActionState.onRefresh}
+                    disabled={faqActionState.loading}
+                    aria-label="刷新FAQ"
+                  >
+                    <RefreshCwIcon className={faqActionState.loading ? "size-4 animate-spin" : "size-4"} />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7"
+                    onClick={() => setDebugPanelOpen(true)}
+                    aria-label="打开调试面板"
+                  >
+                    <Bug className="size-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7"
+                    onClick={faqActionState.onCreate}
+                    aria-label="新增FAQ"
+                  >
+                    <PlusIcon className="size-4" />
+                  </Button>
+                </div>
+              ) : null}
             </div>
           </div>
           <TabsContent value="documents" className="min-h-0 flex-1">
-            <DocumentList 
-              knowledgeBaseId={selectedKnowledgeBase?.id ?? null}
-              onActionStateChange={setDocumentActionState}
-            />
+            {isFAQKnowledgeBase ? (
+              <FAQList
+                knowledgeBaseId={selectedKnowledgeBase?.id ?? null}
+                onActionStateChange={setFAQActionState}
+              />
+            ) : (
+              <DocumentList 
+                knowledgeBaseId={selectedKnowledgeBase?.id ?? null}
+                onActionStateChange={setDocumentActionState}
+              />
+            )}
           </TabsContent>
           <TabsContent value="retrieveLogs" className="min-h-0 flex-1">
             <RetrieveLogList

--- a/web/lib/api/admin.ts
+++ b/web/lib/api/admin.ts
@@ -1095,6 +1095,8 @@ export type KnowledgeBase = {
   id: number
   name: string
   description: string
+  knowledgeType: string
+  knowledgeTypeName: string
   status: number
   statusName: string
   defaultTopK: number
@@ -1109,6 +1111,7 @@ export type KnowledgeBase = {
   fallbackMode: number
   fallbackModeName: string
   documentCount: number
+  faqCount: number
   remark: string
   createdAt: string
   updatedAt: string
@@ -1119,6 +1122,7 @@ export type KnowledgeBase = {
 export type CreateKnowledgeBasePayload = {
   name: string
   description: string
+  knowledgeType: string
   defaultTopK: number
   defaultScoreThreshold: number
   defaultRerankLimit: number
@@ -1155,11 +1159,29 @@ export type KnowledgeDocument = {
   updateUserName: string
 }
 
+export type KnowledgeFAQ = {
+  id: number
+  knowledgeBaseId: number
+  knowledgeBaseName?: string
+  question: string
+  answer: string
+  similarQuestions: string[]
+  status: number
+  statusName: string
+  remark: string
+  createdAt: string
+  updatedAt: string
+  createUserName: string
+  updateUserName: string
+}
+
 export type KnowledgeSearchResult = {
   knowledgeBaseId: number
   chunkId: number
   documentId: number
   documentTitle: string
+  faqId: number
+  faqQuestion: string
   chunkNo: number
   title: string
   sectionPath: string
@@ -1197,6 +1219,8 @@ export type KnowledgeAnswerResponse = {
 export type KnowledgeCitation = {
   documentId: number
   documentTitle: string
+  faqId: number
+  faqQuestion: string
   chunkNo: number
   title: string
   sectionPath: string
@@ -1264,6 +1288,8 @@ export type KnowledgeRetrieveHit = {
   chunkId: number
   documentId: number
   documentTitle: string
+  faqId: number
+  faqQuestion: string
   chunkNo: number
   title: string
   sectionPath: string
@@ -1326,6 +1352,18 @@ export type CreateKnowledgeDocumentPayload = {
 }
 
 export type UpdateKnowledgeDocumentPayload = CreateKnowledgeDocumentPayload & {
+  id: number
+}
+
+export type CreateKnowledgeFAQPayload = {
+  knowledgeBaseId: number
+  question: string
+  answer: string
+  similarQuestions: string[]
+  remark: string
+}
+
+export type UpdateKnowledgeFAQPayload = CreateKnowledgeFAQPayload & {
   id: number
 }
 
@@ -1421,6 +1459,39 @@ export function buildKnowledgeDocumentIndex(documentId: number) {
   return request<void>("/api/console/knowledge-retrieve/build", {
     method: "POST",
     body: JSON.stringify({ documentId }),
+  })
+}
+
+export function fetchKnowledgeFAQs(
+  query?: Record<string, string | number | undefined>
+) {
+  return request<PageResult<KnowledgeFAQ>>(
+    `/api/console/knowledge-faq/list${toQueryString(query)}`
+  )
+}
+
+export function fetchKnowledgeFAQ(id: number) {
+  return request<KnowledgeFAQ>(`/api/console/knowledge-faq/${id}`)
+}
+
+export function createKnowledgeFAQ(payload: CreateKnowledgeFAQPayload) {
+  return request<KnowledgeFAQ>("/api/console/knowledge-faq/create", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  })
+}
+
+export function updateKnowledgeFAQ(payload: UpdateKnowledgeFAQPayload) {
+  return request<void>("/api/console/knowledge-faq/update", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  })
+}
+
+export function deleteKnowledgeFAQ(id: number) {
+  return request<void>("/api/console/knowledge-faq/delete", {
+    method: "POST",
+    body: JSON.stringify({ id }),
   })
 }
 

--- a/web/lib/generated/enums.ts
+++ b/web/lib/generated/enums.ts
@@ -137,6 +137,7 @@ export enum IMEventType {
   Transfer = "transfer",
   Close = "close",
   MessageSend = "message_send",
+  MessageRecall = "message_recall",
 }
 export const IMEventTypeLabels: Record<IMEventType, string> = {
   [IMEventType.Create]: "创建会话",
@@ -144,6 +145,7 @@ export const IMEventTypeLabels: Record<IMEventType, string> = {
   [IMEventType.Transfer]: "转接会话",
   [IMEventType.Close]: "关闭会话",
   [IMEventType.MessageSend]: "发送消息",
+  [IMEventType.MessageRecall]: "撤回消息",
 }
 
 export enum IMMessageStatus {
@@ -166,11 +168,13 @@ export const IMMessageStatusLabels: Record<IMMessageStatus, string> = {
 export enum IMMessageType {
   Text = "text",
   Image = "image",
+  Attachment = "attachment",
   HTML = "html",
 }
 export const IMMessageTypeLabels: Record<IMMessageType, string> = {
   [IMMessageType.Text]: "文本",
   [IMMessageType.Image]: "图片",
+  [IMMessageType.Attachment]: "附件",
   [IMMessageType.HTML]: "富文本",
 }
 
@@ -220,6 +224,15 @@ export const KnowledgeAnswerStatusLabels: Record<KnowledgeAnswerStatus, string> 
   [KnowledgeAnswerStatus.NoAnswer]: "无答案",
   [KnowledgeAnswerStatus.Fallback]: "兜底回复",
   [KnowledgeAnswerStatus.Blocked]: "已屏蔽",
+}
+
+export enum KnowledgeBaseType {
+  Document = "document",
+  FAQ = "faq",
+}
+export const KnowledgeBaseTypeLabels: Record<KnowledgeBaseType, string> = {
+  [KnowledgeBaseType.Document]: "文档知识库",
+  [KnowledgeBaseType.FAQ]: "FAQ知识库",
 }
 
 export enum KnowledgeChunkProvider {
@@ -327,6 +340,15 @@ export const ServiceStatusLabels: Record<ServiceStatus, string> = {
   [ServiceStatus.Busy]: "忙碌",
 }
 
+export enum SkillExecutionMode {
+  PromptOnly = "prompt_only",
+  MCPTool = "mcp_tool",
+}
+export const SkillExecutionModeLabels: Record<SkillExecutionMode, string> = {
+  [SkillExecutionMode.PromptOnly]: "Prompt直出",
+  [SkillExecutionMode.MCPTool]: "MCP工具",
+}
+
 export enum Status {
   Ok = 0,
   Disabled = 1,
@@ -345,6 +367,49 @@ export enum ThirdProvider {
 export const ThirdProviderLabels: Record<ThirdProvider, string> = {
   [ThirdProvider.WxWork]: "企业微信",
   [ThirdProvider.Dingtalk]: "钉钉",
+}
+
+export enum TicketPriority {
+  Low = 1,
+  Normal = 2,
+  High = 3,
+  Urgent = 4,
+}
+export const TicketPriorityLabels: Record<TicketPriority, string> = {
+  [TicketPriority.Low]: "低",
+  [TicketPriority.Normal]: "普通",
+  [TicketPriority.High]: "高",
+  [TicketPriority.Urgent]: "紧急",
+}
+
+export enum TicketSeverity {
+  Minor = 1,
+  Major = 2,
+  Critical = 3,
+}
+export const TicketSeverityLabels: Record<TicketSeverity, string> = {
+  [TicketSeverity.Minor]: "轻微",
+  [TicketSeverity.Major]: "严重",
+  [TicketSeverity.Critical]: "致命",
+}
+
+export enum TicketStatus {
+  New = "new",
+  Open = "open",
+  PendingCustomer = "pending_customer",
+  PendingInternal = "pending_internal",
+  Resolved = "resolved",
+  Closed = "closed",
+  Cancelled = "cancelled",
+}
+export const TicketStatusLabels: Record<TicketStatus, string> = {
+  [TicketStatus.New]: "新建",
+  [TicketStatus.Open]: "处理中",
+  [TicketStatus.PendingCustomer]: "待客户反馈",
+  [TicketStatus.PendingInternal]: "待内部处理",
+  [TicketStatus.Resolved]: "已解决",
+  [TicketStatus.Closed]: "已关闭",
+  [TicketStatus.Cancelled]: "已取消",
 }
 
 export enum VectorDBType {


### PR DESCRIPTION
## Summary
- add `knowledgeType` to knowledge bases to distinguish document and FAQ knowledge bases
- add structured FAQ CRUD APIs, repository/service/controller support, and console FAQ list/edit UI
- route FAQ knowledge bases through dedicated FAQ indexing with `1 FAQ = 1 chunk` instead of text-based FAQ splitting
- update retrieval, citations, logs, and debug views to surface FAQ metadata alongside document metadata
- enforce knowledge base rules so document knowledge bases cannot use the FAQ chunk provider and FAQ knowledge bases cannot manage documents

## Testing
- `make enums`
- `go test ./...`
- `go test ./internal/...`
- `pnpm typecheck` could not run successfully because `web/node_modules` is missing in the workspace