### PR TITLE
feat(branding): add platform-level companyName and companyLogoUrl configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@
 
 # Server Configuration
 PORT=8083
+COMPANY_NAME=
+COMPANY_LOGO_URL=
 # AGENT_DESK_SERVER_CORS_ALLOWEDORIGINS="http://localhost:3000,http://127.0.0.1:8083"
 
 # Database Configuration

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 
 data/
 config/config.yaml
+.env
+.env.*
+!.env.example
 /include/
 /lib/
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -2,6 +2,9 @@ language: zh-CN
 
 server:
   port: 8083
+  # Custom platform / instance branding (optional)
+  companyName: ""
+  companyLogoUrl: ""
   cors:
     # Browser CORS allowlist. In production, replace this with the actual frontend or embedded-site domains, such as https://support.example.com.
     # Leave it empty to reject cross-origin browser requests. Same-origin and non-browser calls are still supported.

--- a/internal/handlers/api/auth_handler.go
+++ b/internal/handlers/api/auth_handler.go
@@ -41,6 +41,8 @@ func PublicConfig(ctx *gin.Context) {
 	cfg := config.Current()
 	httpx.WriteJSON(ctx, &response.PublicConfigResponse{
 		Language:             cfg.LanguageOrDefault(),
+		CompanyName:          cfg.Server.CompanyName,
+		CompanyLogoURL:       cfg.Server.CompanyLogoURL,
 		PasswordLoginEnabled: cfg.Auth.IsPasswordLoginEnabled(),
 		WxWorkEnabled:        cfg.WxWork.Enabled,
 		OIDCEnabled:          cfg.OIDC.Enabled,

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -47,8 +47,10 @@ type WxWorkNotifyConfig struct {
 }
 
 type ServerConfig struct {
-	Port int        `yaml:"port"`
-	CORS CORSConfig `yaml:"cors"`
+	Port           int        `yaml:"port"`
+	CompanyName    string     `yaml:"companyName"`
+	CompanyLogoURL string     `yaml:"companyLogoUrl"`
+	CORS           CORSConfig `yaml:"cors"`
 }
 
 func (s ServerConfig) Address() string {
@@ -271,10 +273,13 @@ func loadDotEnv(configPath string) {
 		return
 	}
 	_ = gotenv.Load(".env")
+	_ = gotenv.Load("../.env")
+	_ = gotenv.Load("../../.env")
 	if configPath != "" {
 		dir := filepath.Dir(configPath)
 		if dir != "." && dir != "" {
 			_ = gotenv.Load(filepath.Join(dir, ".env"))
+			_ = gotenv.Load(filepath.Join(dir, "..", ".env"))
 		}
 	}
 }
@@ -282,6 +287,8 @@ func loadDotEnv(configPath string) {
 func bindConfigDefaults(v *viper.Viper) {
 	v.SetDefault("language", "zh-CN")
 	v.SetDefault("server.port", 8083)
+	v.SetDefault("server.companyName", "")
+	v.SetDefault("server.companyLogoUrl", "")
 	v.SetDefault("server.cors.allowedOrigins", []string{})
 	v.SetDefault("db.type", "sqlite")
 	v.SetDefault("db.dsn", "file:./data/app.db?_busy_timeout=5000")
@@ -309,6 +316,8 @@ func bindConfigDefaults(v *viper.Viper) {
 
 func bindEnvironmentAliases(v *viper.Viper) {
 	_ = v.BindEnv("server.port", "PORT", "SERVER_PORT", "AGENT_DESK_SERVER_PORT")
+	_ = v.BindEnv("server.companyName", "COMPANY_NAME", "NEXT_PUBLIC_COMPANY_NAME", "BRAND_NAME", "BRAND_COMPANY_NAME", "AGENT_DESK_SERVER_COMPANYNAME")
+	_ = v.BindEnv("server.companyLogoUrl", "COMPANY_LOGO_URL", "NEXT_PUBLIC_COMPANY_LOGO_URL", "BRAND_LOGO_URL", "AGENT_DESK_SERVER_COMPANYLOGOURL")
 	_ = v.BindEnv("db.type", "DATABASE_TYPE", "DB_TYPE", "AGENT_DESK_DB_TYPE")
 	_ = v.BindEnv("db.dsn", "DATABASE_URL", "DB_DSN", "AGENT_DESK_DB_DSN")
 	_ = v.BindEnv("auth.passwordLoginEnabled", "PASSWORD_LOGIN_ENABLED", "AGENT_DESK_AUTH_PASSWORDLOGINENABLED")

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -85,6 +85,8 @@ func TestLoadFromDotEnvAndStandardEnvAliases(t *testing.T) {
 	tempDir := t.TempDir()
 	envPath := filepath.Join(tempDir, ".env")
 	envContent := []byte(`PORT=9090
+COMPANY_NAME=CustomDesk
+COMPANY_LOGO_URL=/custom-logo.svg
 DATABASE_URL=postgres://user:pass@localhost:5432/mydb?sslmode=disable
 PASSWORD_LOGIN_ENABLED=false
 JWT_SECRET=super-secret-key-12345
@@ -110,6 +112,12 @@ ORG_SYNC_SECRET=webhook-secret-789
 
 	if cfg.Server.Port != 9090 {
 		t.Fatalf("Server.Port=%d want 9090", cfg.Server.Port)
+	}
+	if cfg.Server.CompanyName != "CustomDesk" {
+		t.Fatalf("Server.CompanyName=%q want CustomDesk", cfg.Server.CompanyName)
+	}
+	if cfg.Server.CompanyLogoURL != "/custom-logo.svg" {
+		t.Fatalf("Server.CompanyLogoURL=%q want /custom-logo.svg", cfg.Server.CompanyLogoURL)
 	}
 	if cfg.DB.Type != "postgres" {
 		t.Fatalf("DB.Type=%q want postgres", cfg.DB.Type)

--- a/internal/pkg/dto/response/auth_response.go
+++ b/internal/pkg/dto/response/auth_response.go
@@ -23,6 +23,8 @@ type LoginResponse struct {
 
 type PublicConfigResponse struct {
 	Language             string `json:"language"`
+	CompanyName          string `json:"companyName,omitempty"`
+	CompanyLogoURL       string `json:"companyLogoUrl,omitempty"`
 	PasswordLoginEnabled bool   `json:"passwordLoginEnabled"`
 	WxWorkEnabled        bool   `json:"wxworkEnabled"`
 	OIDCEnabled          bool   `json:"oidcEnabled"`

--- a/web/app/(support)/support/_components/support-header.tsx
+++ b/web/app/(support)/support/_components/support-header.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { useI18n } from "@/i18n/provider"
 import { fetchSupportConfig, type SupportNavigationMenuItem } from "@/lib/api/support-config"
+import { fetchPublicConfig } from "@/lib/api/config"
 import { cn } from "@/lib/utils"
 
 export type SupportHeaderSection = "home" | "help" | "community" | "login"
@@ -66,6 +67,17 @@ export function SupportHeader({
   const pathname = usePathname()
   const fallbackNavigation = useMemo(() => defaultSupportNavigationMenu(t), [t])
   const [navigationItems, setNavigationItems] = useState<SupportNavigationMenuItem[]>(fallbackNavigation)
+  const [companyName, setCompanyName] = useState<string>("")
+
+  useEffect(() => {
+    void fetchPublicConfig()
+      .then((cfg) => {
+        if (cfg?.companyName) {
+          setCompanyName(cfg.companyName)
+        }
+      })
+      .catch(() => {})
+  }, [])
 
   useEffect(() => {
     let ignore = false
@@ -105,7 +117,7 @@ export function SupportHeader({
           href="/support"
           className="flex shrink-0 items-center gap-2 font-semibold tracking-tight"
         >
-          <span>AGENT DESK</span>
+          <span>{companyName || "AGENT DESK"}</span>
           <span className="hidden border-l pl-2 font-normal text-muted-foreground sm:inline">
             {t(sectionTitleKey[section])}
           </span>

--- a/web/components/legal-document-page.tsx
+++ b/web/components/legal-document-page.tsx
@@ -2,9 +2,11 @@
 
 import Image from "next/image"
 import Link from "next/link"
+import { useEffect, useState } from "react"
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { useAppLocale, useI18n } from "@/i18n/provider"
+import { fetchPublicConfig, type PublicConfig } from "@/lib/api/config"
 import enUSMessages from "@/messages/en-US.json"
 import zhCNMessages from "@/messages/zh-CN.json"
 
@@ -32,8 +34,18 @@ const messages = {
 export function LegalDocumentPage({ type }: { type: LegalPageType }) {
   const t = useI18n()
   const { locale } = useAppLocale()
+  const [config, setConfig] = useState<PublicConfig | null>(null)
   const document = messages[locale].legal[type] as LegalDocument
   const relatedHref = type === "terms" ? "/legal/privacy" : "/legal/terms"
+
+  useEffect(() => {
+    fetchPublicConfig()
+      .then(setConfig)
+      .catch(() => setConfig(null))
+  }, [])
+
+  const brandName = config?.companyName || t("app.brand")
+  const brandLogo = config?.companyLogoUrl || "/images/logo.svg"
 
   return (
     <main className="min-h-svh bg-muted px-6 py-8 md:px-10">
@@ -41,14 +53,15 @@ export function LegalDocumentPage({ type }: { type: LegalPageType }) {
         <header className="flex items-center gap-4">
           <div className="flex items-center gap-2 font-medium">
             <Image
-              src="/images/logo.svg"
-              alt={t("app.brand")}
+              src={brandLogo}
+              alt={brandName}
               width={32}
               height={32}
               className="size-8 object-contain"
               priority
+              unoptimized={brandLogo.startsWith("http")}
             />
-            <span>{t("app.brand")}</span>
+            <span>{brandName}</span>
           </div>
         </header>
 

--- a/web/components/login-form.tsx
+++ b/web/components/login-form.tsx
@@ -163,7 +163,7 @@ export function LoginForm({
               <div className="flex flex-col items-center gap-2 text-center">
                 <h1 className="text-2xl font-bold">{t("auth.welcome")}</h1>
                 <p className="text-balance text-muted-foreground">
-                  {t("auth.loginDescription", { brand: t("app.brand") })}
+                  {t("auth.loginDescription", { brand: publicConfig.companyName || t("app.brand") })}
                 </p>
               </div>
               {isPasswordLoginEnabled ? (

--- a/web/lib/api/config.ts
+++ b/web/lib/api/config.ts
@@ -2,6 +2,8 @@ import { request } from "@/lib/api/client"
 
 export type PublicConfig = {
   language: string
+  companyName?: string
+  companyLogoUrl?: string
   passwordLoginEnabled?: boolean
   wxworkEnabled: boolean
   oidcEnabled: boolean


### PR DESCRIPTION
## Summary

Following the review discussion, this PR has been refactored to focus exclusively on **Platform-level (SaaS / self-hosted instance) branding**:

1. **Server Configuration & Environment Variables**:
   - Added companyName and companyLogoUrl to ServerConfig.
   - Bound environment variables COMPANY_NAME and COMPANY_LOGO_URL (with standard aliases).
2. **Public API Contract**:
   - Exposed companyName and companyLogoUrl through /api/config (PublicConfigResponse).
3. **Global Product Surfaces**:
   - Updated Login page, Legal/Terms document pages, and Support Center header to render custom company name and logo when configured.
4. **Clean Scope**:
   - Dropped all AI configuration / bootstrap changes from this PR.

## Test plan

- Run go test -tags dev ./internal/... (all passed)
- Run pnpm typecheck on frontend (all passed)