### PR TITLE
fix(ui): fix font-sans theme variable resolution and root layout font binding

### DIFF
--- a/web/app/(dashboard)/dashboard.css
+++ b/web/app/(dashboard)/dashboard.css
@@ -7,8 +7,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-geist-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/web/app/(dashboard)/layout.tsx
+++ b/web/app/(dashboard)/layout.tsx
@@ -44,9 +44,9 @@ export default function DashboardRootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en-US" suppressHydrationWarning>
+    <html lang="en-US" className={`${geistSans.variable} ${geistMono.variable}`} suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className="antialiased font-sans"
       >
         <script dangerouslySetInnerHTML={{ __html: paletteScript }} />
         <AppI18nProvider>

--- a/web/app/(support)/layout.tsx
+++ b/web/app/(support)/layout.tsx
@@ -33,9 +33,9 @@ export default function SupportRootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en-US" suppressHydrationWarning>
+    <html lang="en-US" className={`${geistSans.variable} ${geistMono.variable}`} suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className="antialiased font-sans"
       >
         <AppI18nProvider>
           <ThemeProvider>

--- a/web/app/(support)/support.css
+++ b/web/app/(support)/support.css
@@ -8,8 +8,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-geist-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);


### PR DESCRIPTION
## Summary

- **Fix font-sans theme variable resolution in dashboard.css**: `--font-sans: var(--font-sans)` had a circular self-reference, preventing the browser from resolving the Geist font and causing text to fall back to the system default serif font (Times New Roman). Fixed to `--font-sans: var(--font-geist-sans), ...`.
- **Root font CSS variable injection**: Moved `${geistSans.variable} ${geistMono.variable}` from `<body>` to the root `<html>` element in both dashboard and support layouts so CSS variables are available globally when `@layer base { html { @apply font-sans; } }` is evaluated.
- **Font fallbacks**: Added standard fallback font family stack (`-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif`) to ensure smooth rendering before web fonts load.

## Test plan

- Checked dashboard and support center pages across browsers to verify that `font-sans` correctly applies the sans-serif font stack without serif fallback.
- Run `pnpm typecheck` on frontend (passed).
