### PR TITLE
chore: remove docs submodule pointing to a private repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,4 @@
 [submodule "qdrant"]
 	path = qdrant
 	url = git@github.com:huabeitech/agent-desk-qdrant.git
-[submodule "docs"]
-	path = docs
-	url = git@github.com:huabeitech/agent-desk-docs.git
+


### PR DESCRIPTION
## Problem

`.gitmodules` registers a `docs` submodule pointing to `huabeitech/agent-desk-docs`, which is not publicly accessible — the URL returns **404** (https://github.com/huabeitech/agent-desk-docs).

Every fork or fresh clone that runs `git submodule update --init` (or clones with `--recurse-submodules`) fails on it:

```
fatal: repository 'https://github.com/huabeitech/agent-desk-docs.git/' not found
fatal: clone of 'git@github.com:huabeitech/agent-desk-docs.git' into submodule path 'docs' failed
```

## Fix

Remove the `docs` gitlink and its `.gitmodules` entry.

- No source code is affected — the submodule only carries a documentation-site checkout.
- The `qdrant` submodule is public and is kept as-is.
- An alternative fix is to make `huabeitech/agent-desk-docs` public; removing the pointer works either way and keeps forks and CI green.
