### PR TITLE
fix(auth): initialize bootstrap admin as employee

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Go Tests
         run: |
-          go test -v -tags dev ./internal/services/... ./internal/repositories/... ./internal/pkg/... ./internal/oidcclient/...
+          go test -v -tags dev ./internal/services/... ./internal/repositories/... ./internal/pkg/... ./internal/oidcclient/... ./internal/migration/...
 
   frontend-typecheck:
     name: Frontend Typecheck

--- a/internal/migration/000002_init_auth_data.go
+++ b/internal/migration/000002_init_auth_data.go
@@ -205,6 +205,7 @@ func ensureBootstrapAdmin(tx *gorm.DB, superAdminRole *models.Role) error {
 			Username: username,
 			Nickname: nickname,
 			Password: string(hashedPassword),
+			UserType: enums.UserTypeEmployee,
 			Status:   enums.StatusOk,
 			Remark:   "bootstrap super admin",
 			AuditFields: models.AuditFields{

--- a/internal/migration/000010_repair_bootstrap_admin_user_type.go
+++ b/internal/migration/000010_repair_bootstrap_admin_user_type.go
@@ -1,0 +1,34 @@
+package migration
+
+import (
+	"agent-desk/internal/models"
+	"agent-desk/internal/pkg/constants"
+	"agent-desk/internal/pkg/enums"
+	"time"
+
+	"github.com/mlogclub/simple/sqls"
+)
+
+func init() {
+	register(10, "repair bootstrap admin user type", func() error {
+		db := sqls.DB()
+		superAdmins := db.Table("t_user_role AS ur").Select("ur.user_id").
+			Joins("JOIN t_role AS r ON r.id = ur.role_id").
+			Where("r.code = ? AND r.status = ?", constants.RoleCodeSuperAdmin, enums.StatusOk)
+
+		// Migration 2 has already run on existing installations. Repair only the
+		// active bootstrap account that already has the super admin role.
+		return db.Model(&models.User{}).
+			Where("username = ?", constants.BootstrapAdminUsername).
+			Where("user_type = ?", enums.UserTypeUser).
+			Where("status = ?", enums.StatusOk).
+			Where("deleted_at IS NULL").
+			Where("id IN (?)", superAdmins).
+			Updates(map[string]any{
+				"user_type":        enums.UserTypeEmployee,
+				"updated_at":       time.Now(),
+				"update_user_id":   constants.SystemAuditUserID,
+				"update_user_name": constants.SystemAuditUserName,
+			}).Error
+	})
+}

--- a/internal/migration/000010_repair_bootstrap_admin_user_type_test.go
+++ b/internal/migration/000010_repair_bootstrap_admin_user_type_test.go
@@ -1,0 +1,131 @@
+package migration
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"agent-desk/internal/models"
+	"agent-desk/internal/pkg/constants"
+	"agent-desk/internal/pkg/enums"
+	"github.com/glebarez/sqlite"
+	"github.com/mlogclub/simple/sqls"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+func setupBootstrapAdminTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "auth.db")), &gorm.Config{
+		NamingStrategy: schema.NamingStrategy{TablePrefix: "t_", SingularTable: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.Role{}, &models.UserRole{}); err != nil {
+		t.Fatal(err)
+	}
+	conn, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return db
+}
+
+func TestBootstrapAdminCreatedAsEmployee(t *testing.T) {
+	db := setupBootstrapAdminTestDB(t)
+	role := models.Role{Code: constants.RoleCodeSuperAdmin, Status: enums.StatusOk}
+	if err := db.Create(&role).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureBootstrapAdmin(db, &role); err != nil {
+		t.Fatal(err)
+	}
+	var user models.User
+	if err := db.Where("username = ?", constants.BootstrapAdminUsername).First(&user).Error; err != nil {
+		t.Fatal(err)
+	}
+	if user.UserType != enums.UserTypeEmployee {
+		t.Fatalf("bootstrap admin type = %q, want employee", user.UserType)
+	}
+	var count int64
+	if err := db.Model(&models.UserRole{}).Where("user_id = ? AND role_id = ?", user.ID, role.ID).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("super admin role assignments = %d, want 1", count)
+	}
+}
+
+func TestRepairBootstrapAdminUserType(t *testing.T) {
+	repair, ok := migrationFuncs[10]
+	if !ok {
+		t.Fatal("bootstrap admin repair migration is not registered")
+	}
+	for _, tc := range []struct {
+		name       string
+		username   string
+		userType   enums.UserType
+		status     enums.Status
+		roleCode   string
+		roleStatus enums.Status
+		deleted    bool
+		want       enums.UserType
+	}{
+		{"legacy admin", "admin", enums.UserTypeUser, enums.StatusOk, constants.RoleCodeSuperAdmin, enums.StatusOk, false, enums.UserTypeEmployee},
+		{"already employee", "admin", enums.UserTypeEmployee, enums.StatusOk, constants.RoleCodeSuperAdmin, enums.StatusOk, false, enums.UserTypeEmployee},
+		{"ordinary user", "customer", enums.UserTypeUser, enums.StatusOk, "", enums.StatusOk, false, enums.UserTypeUser},
+		{"same name without role", "admin", enums.UserTypeUser, enums.StatusOk, "", enums.StatusOk, false, enums.UserTypeUser},
+		{"other super admin", "other", enums.UserTypeUser, enums.StatusOk, constants.RoleCodeSuperAdmin, enums.StatusOk, false, enums.UserTypeUser},
+		{"disabled admin", "admin", enums.UserTypeUser, enums.StatusDisabled, constants.RoleCodeSuperAdmin, enums.StatusOk, false, enums.UserTypeUser},
+		{"disabled role", "admin", enums.UserTypeUser, enums.StatusOk, constants.RoleCodeSuperAdmin, enums.StatusDisabled, false, enums.UserTypeUser},
+		{"deleted admin", "admin", enums.UserTypeUser, enums.StatusOk, constants.RoleCodeSuperAdmin, enums.StatusOk, true, enums.UserTypeUser},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := setupBootstrapAdminTestDB(t)
+			sqls.SetDB(db)
+			t.Cleanup(func() { sqls.SetDB(nil) })
+			user := models.User{Username: tc.username, Password: "unchanged-test-value", UserType: tc.userType, Status: tc.status}
+			if tc.deleted {
+				now := time.Now()
+				user.DeletedAt = &now
+			}
+			if err := db.Create(&user).Error; err != nil {
+				t.Fatal(err)
+			}
+			if tc.roleCode != "" {
+				role := models.Role{Code: tc.roleCode, Status: tc.roleStatus}
+				if err := db.Create(&role).Error; err != nil {
+					t.Fatal(err)
+				}
+				if err := db.Create(&models.UserRole{UserID: user.ID, RoleID: role.ID}).Error; err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := repair.Fn(); err != nil {
+				t.Fatal(err)
+			}
+			var got models.User
+			if err := db.First(&got, user.ID).Error; err != nil {
+				t.Fatal(err)
+			}
+			if got.UserType != tc.want {
+				t.Fatalf("type = %q, want %q", got.UserType, tc.want)
+			}
+			if got.Password != user.Password || got.Status != user.Status {
+				t.Fatal("repair changed password or account status")
+			}
+			updatedAt := got.UpdatedAt
+			if err := repair.Fn(); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.First(&got, user.ID).Error; err != nil {
+				t.Fatal(err)
+			}
+			if !got.UpdatedAt.Equal(updatedAt) {
+				t.Fatal("second repair changed updated_at")
+			}
+		})
+	}
+}


### PR DESCRIPTION
The bootstrap `admin` receives the `super_admin` role but inherits `user_type=user`, so dashboard authentication rejects it. Initialize it as `employee` and add migration 10 to repair existing installations where migration 2 has already succeeded.

The repair only updates the active, non-deleted default admin with an active `super_admin` role and `user_type=user`. It preserves passwords, account status and role assignments, and is idempotent. This uses the existing enums and migration framework.

Fixes #36.

Validation:
- Reproduced the incorrect bootstrap type with a failing regression test before applying the fix.
- Passed bootstrap creation and repair tests, including ordinary users, missing roles, disabled/deleted accounts and repeated execution.
- Passed the existing backend CI test suite plus `./internal/migration/...` with Go 1.26 and `-tags dev`.
- Ran `gofmt` and `git diff --check`.

The migration regression tests use SQLite. A MySQL integration run was not performed.
